### PR TITLE
README: Add notes about phx.server in order

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,12 @@ Assumed to be run *outside* of devbox, at the time of writing.
 
 First time:
 
+    # Edit the `config/test.exs` and `config/dev.exs` to set a Postgres username
     # Creates DB and migrates
     mix ecto.setup
+    mix phx.server
 
-    # Get some fake data via the webhook
+    # In a a new shell: Get some fake data via the webhook
     mix wh.commits
     mix wh.comments
 


### PR DESCRIPTION
Without this, the reader has to fail at the next step - mix wh.commits - due to the server not running.