### PR TITLE
Revamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,9 @@ First time:
     # Optionally, seed comment notifications addressed to your own GitHub username:
     mix fake.notifications YOUR_GITHUB_USERNAME
 
+    # Optionally, seed build/deploy commits (requires existing commits in DB):
+    mix wh.build_commits
+
 Every time:
 
     # Ensure you have the Node version given in .nvmrc, e.g. by installing "nvm" and doing this (TODO: Improve this by moving into Devbox):
@@ -295,6 +298,12 @@ You can also specify which users commits to generate comments for by passising t
 Bear in mind that for this to work, there must exist commits by that username in the database. This can be accomplished by passing the `--author` flag when generating commits.
 
     mix wh.commits --author username
+
+To add fake build/deploy commits (which reference existing commits by SHA), run:
+
+    mix wh.build_commits
+
+This requires existing commits in the DB. You can pass `--count` and `--repo` (defaults to "stack").
 
 ### Working on the connection detection
 

--- a/assets/css/_base.css
+++ b/assets/css/_base.css
@@ -2,12 +2,31 @@
  * For base styling of different elements. No class/ID selectors.
  */
 
+:root {
+  --color-white:      #ffffff;
+  --color-gray-200:   #e5e7eb;  /* gray-200 */
+  --color-gray-light: #d1d5db;  /* gray-300 */
+  --color-gray-mid:   #6b7280;  /* gray-500 */
+  --color-gray-dark:  #4b5563;  /* gray-600 */
+  --color-almost-black: #111827; /* gray-900 */
+}
+
+.dark {
+  --color-white:      #111827;  /* gray-900 */
+  --color-gray-200:   #1f2937;  /* gray-800 */
+  --color-gray-light: #4b5563;  /* gray-600 */
+  --color-gray-mid:   #9ca3af;  /* gray-400 */
+  --color-gray-dark:  #d1d5db;  /* gray-300 */
+  --color-almost-black: #f9fafb; /* gray-50 */
+}
+
 body {
-  @apply text-xs;
+  @apply text-xs text-almost-black;
 }
 
 button {
   @apply px-1 border border-solid border-gray-mid rounded bg-gray-200;
+  color: inherit;
 
   &:focus {
     /* Worse for keyboard navigation, but the outlines don't look good in this UI. */
@@ -21,6 +40,7 @@ button {
 
 a {
   @apply underline;
+  color: inherit;
 }
 
 label {
@@ -29,7 +49,13 @@ label {
 
 input[type=text],
 input[type=email] {
-  @apply border border-gray-mid py-1 px-2;
+  @apply border border-gray-mid py-1 px-2 bg-gray-200;
+  color: inherit;
   max-width: 100%;
+}
+
+select {
+  @apply border border-gray-mid bg-gray-200;
+  color: inherit;
 }
 

--- a/assets/css/_base.css
+++ b/assets/css/_base.css
@@ -44,7 +44,7 @@ a {
 }
 
 label {
-  @apply font-bold mr-3 block mb-2;
+  @apply mr-3 block mb-2;
 }
 
 input[type=text],

--- a/assets/css/_components.css
+++ b/assets/css/_components.css
@@ -43,6 +43,22 @@
       &.tabs__tab--settings i { @apply text-blue-500; }
     }
   }
+
+  &--compact {
+    @apply border-b border-gray-light;
+
+    .tabs__tab {
+      @apply bg-transparent border-r-0 border-b-2 border-transparent text-gray-500;
+      @apply hover:text-gray-700 dark:hover:text-gray-300;
+
+      &--current {
+        @apply bg-transparent text-almost-black border-b-2;
+        &.tabs__tab--commits { @apply border-green-500; }
+        &.tabs__tab--comments { @apply border-yellow-500; }
+        &.tabs__tab--settings { @apply border-blue-500; }
+      }
+    }
+  }
 }
 
 .info-box {

--- a/assets/css/_components.css
+++ b/assets/css/_components.css
@@ -16,7 +16,7 @@
     &:last-child { border-right: 0; }
 
     .tabs__tab__text {
-      @apply ml-1;
+      @apply ml-2;
     }
 
     &.tabs__tab--settings {

--- a/assets/css/_components.css
+++ b/assets/css/_components.css
@@ -7,7 +7,7 @@
   @apply flex;
 
   &__tab {
-    @apply text-sm py-1 px-2 flex-1 text-center border-r border-b border-gray-mid bg-gray-100;
+    @apply text-sm py-1 px-2 flex-1 text-center border-r border-b border-gray-mid bg-gray-200;
     @apply no-underline;
     @apply sm:text-base sm:py-2 sm:px-3;
 
@@ -56,22 +56,30 @@
 .commit {
   &--highlight {
     @apply bg-yellow-200;
+    .dark & { @apply bg-blue-900; }
   }
   &--reviewed {
     @apply bg-green-light;
   }
   &--highlight&--reviewed {
     @apply bg-chartreuse;
+    .dark & { @apply bg-blue-900; }
   }
   &--being-reviewed {
     @apply bg-blue-100;
+    .dark & { @apply bg-blue-900; }
   }
   &--highlight&--being-reviewed {
     @apply bg-chartreuse;
+    .dark & { @apply bg-blue-900; }
   }
 }
 
 .comment {
+  .comment__metadata {
+    .dark & { @apply bg-gray-700; }
+  }
+
   &--resolved {
     @apply opacity-50;
   }
@@ -79,6 +87,7 @@
   &--highlight {
     .comment__metadata {
       @apply bg-yellow-300;
+      .dark & { @apply bg-blue-900; }
     }
   }
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -535,6 +535,14 @@ Hooks.FeatureToggle = {
 }
 
 document.addEventListener('click', (e) => {
+  const deployedEl = e.target.closest('[data-deployed-url]')
+  if (deployedEl?.dataset.deployedUrl) {
+    e.stopPropagation()
+    e.preventDefault()
+    window.open(deployedEl.dataset.deployedUrl, window.fluid ? '_self' : 'github_window')
+    return
+  }
+
   const btn = e.target.closest('[data-clipboard-copy]')
   if (!btn) return
   e.stopPropagation()

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -284,7 +284,7 @@ Hooks.CommitSearch = {
 
   makeCheckboxLabel(text, value, checked, onChange) {
     const label = document.createElement('label')
-    label.className = 'flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer'
+    label.className = 'flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap'
     const cb = document.createElement('input')
     cb.type = 'checkbox'
     cb.checked = checked

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -149,12 +149,13 @@ Hooks.CommitSearch = {
     // Checkbox changes via event delegation
     this.el.addEventListener('change', (e) => {
       const cb = e.target
-      if (!cb.matches('input[type="checkbox"]')) return
+      if (!cb.matches('input[type="checkbox"], input[type="radio"]')) return
 
       if ('projectsAll' in cb.dataset) { this.clearSet(this.selectedProjectTeams, '[data-projects-team]'); this.onFilterChange(); return }
       if ('projectsTeam' in cb.dataset) { this.toggleInSet(this.selectedProjectTeams, cb.dataset.projectsTeam, cb.checked); this.onFilterChange(); return }
       if ('membersAll' in cb.dataset) { this.clearSet(this.selectedMemberTeams, '[data-members-team]'); this.onFilterChange(); return }
       if ('membersTeam' in cb.dataset) { this.toggleInSet(this.selectedMemberTeams, cb.dataset.membersTeam, cb.checked); this.onFilterChange(); return }
+      if ('statusValue' in cb.dataset) { this.reviewedFilter = cb.dataset.statusValue; this.onFilterChange(); return }
     })
 
     this._closeDropdown = (e) => {
@@ -224,12 +225,14 @@ Hooks.CommitSearch = {
       this.selectedProjectTeams = new Set(s.projectTeams || [])
       this.selectedMemberTeams = new Set(s.memberTeams || [])
       this.searchQuery = s.search || ''
+      this.reviewedFilter = s.reviewedFilter || 'all'
     } catch (_) {
       this.selectedRepos = new Set()
       this.selectedAuthors = new Set()
       this.selectedProjectTeams = new Set()
       this.selectedMemberTeams = new Set()
       this.searchQuery = ''
+      this.reviewedFilter = 'all'
     }
   },
 
@@ -240,6 +243,7 @@ Hooks.CommitSearch = {
       projectTeams: [...this.selectedProjectTeams],
       memberTeams: [...this.selectedMemberTeams],
       search: this.searchQuery,
+      reviewedFilter: this.reviewedFilter,
     }))
   },
 
@@ -309,8 +313,12 @@ Hooks.CommitSearch = {
     this.el.querySelectorAll('[data-projects-team]').forEach(cb => { cb.checked = this.selectedProjectTeams.has(cb.dataset.projectsTeam) })
     this.el.querySelectorAll('[data-members-all]').forEach(cb => { cb.checked = this.selectedMemberTeams.size === 0 })
     this.el.querySelectorAll('[data-members-team]').forEach(cb => { cb.checked = this.selectedMemberTeams.has(cb.dataset.membersTeam) })
+    this.el.querySelectorAll('[data-status-value]').forEach(radio => { radio.checked = radio.dataset.statusValue === this.reviewedFilter })
     this.updateLabel('[data-projects-label]', this.selectedProjectTeams, 'Projects')
     this.updateLabel('[data-members-label]', this.selectedMemberTeams, 'Members')
+    const statusLabels = { 'all': 'Status', 'unreviewed': 'Unreviewed', 'reviewed': 'Reviewed' }
+    const statusLabelEl = this.el.querySelector('[data-status-label]')
+    if (statusLabelEl) statusLabelEl.textContent = statusLabels[this.reviewedFilter] || 'Status'
   },
 
   // ── Labels & button state ─────────────────────────────────────────────────
@@ -331,6 +339,7 @@ Hooks.CommitSearch = {
     ].forEach(([sel, set]) => {
       this.el.querySelectorAll(sel).forEach(dot => dot.classList.toggle('hidden', set.size === 0))
     })
+    this.el.querySelectorAll('[data-status-active]').forEach(dot => dot.classList.toggle('hidden', this.reviewedFilter === 'all'))
   },
 
   // ── Filtering ─────────────────────────────────────────────────────────────
@@ -355,7 +364,141 @@ Hooks.CommitSearch = {
         (this.selectedRepos.size === 0 || this.selectedRepos.has(item.dataset.repo)) &&
         (this.selectedAuthors.size === 0 || authors.some(a => this.selectedAuthors.has(a))) &&
         (this.selectedProjectTeams.size === 0 || projectTeams.some(t => this.selectedProjectTeams.has(t))) &&
-        (this.selectedMemberTeams.size === 0 || memberTeams.some(t => this.selectedMemberTeams.has(t)))
+        (this.selectedMemberTeams.size === 0 || memberTeams.some(t => this.selectedMemberTeams.has(t))) &&
+        (this.reviewedFilter === 'all' ||
+          (this.reviewedFilter === 'reviewed' && item.dataset.reviewed === 'true') ||
+          (this.reviewedFilter === 'unreviewed' && item.dataset.reviewed === 'false'))
+
+      wrapper.classList.toggle('hidden', !ok)
+    })
+  },
+}
+
+Hooks.CommentSearch = {
+  storageKey: 'remit:comment_filters',
+
+  mounted() {
+    this.isLoggedIn = !!this.el.dataset.username
+    this.loadPreferences()
+
+    const searchInput = this.el.querySelector('[data-comment-search]')
+    if (searchInput) {
+      if (this.searchQuery) searchInput.value = this.searchQuery
+      searchInput.addEventListener('input', (e) => {
+        this.searchQuery = e.target.value.toLowerCase()
+        this.savePreferences()
+        this.filterComments()
+      })
+    }
+
+    this.el.addEventListener('click', (e) => {
+      const filterToggle = e.target.closest('[data-filter-dropdown-toggle]')
+      if (filterToggle) {
+        e.stopPropagation()
+        const dropdown = filterToggle.closest('[data-filter-dropdown]')
+        const panel = dropdown?.querySelector('[data-filter-dropdown-panel]')
+        const chevron = filterToggle.querySelector('[data-filter-chevron]')
+        const isOpen = !panel?.classList.contains('hidden')
+        this.closeAllDropdowns()
+        if (!isOpen) { panel?.classList.remove('hidden'); chevron?.classList.add('rotate-180') }
+        return
+      }
+    })
+
+    this.el.addEventListener('change', (e) => {
+      const input = e.target
+      if (!input.matches('input[type="radio"]')) return
+      if ('commentStatusValue' in input.dataset) { this.resolvedFilter = input.dataset.commentStatusValue; this.onFilterChange(); return }
+      if ('commentRoleValue' in input.dataset) { this.roleFilter = input.dataset.commentRoleValue; this.onFilterChange(); return }
+    })
+
+    this._closeDropdown = (e) => {
+      if (!e.target.closest('[data-filter-dropdown]')) this.closeAllDropdowns()
+    }
+    document.addEventListener('click', this._closeDropdown)
+
+    this.syncStaticInputs()
+    this.syncButtonStates()
+    this.filterComments()
+  },
+
+  destroyed() {
+    document.removeEventListener('click', this._closeDropdown)
+  },
+
+  updated() {
+    this.syncStaticInputs()
+    this.syncButtonStates()
+    this.filterComments()
+  },
+
+  closeAllDropdowns() {
+    this.el.querySelectorAll('[data-filter-dropdown-panel]').forEach(p => p.classList.add('hidden'))
+    this.el.querySelectorAll('[data-filter-dropdown-toggle] [data-filter-chevron]').forEach(c => c.classList.remove('rotate-180'))
+  },
+
+  onFilterChange() {
+    this.savePreferences()
+    this.syncStaticInputs()
+    this.syncButtonStates()
+    this.filterComments()
+  },
+
+  loadPreferences() {
+    try {
+      const s = JSON.parse(localStorage.getItem(this.storageKey) || '{}')
+      this.resolvedFilter = s.resolvedFilter || 'unresolved'
+      this.roleFilter = s.roleFilter || (this.isLoggedIn ? 'for_me' : 'all')
+      this.searchQuery = s.search || ''
+    } catch (_) {
+      this.resolvedFilter = 'unresolved'
+      this.roleFilter = this.isLoggedIn ? 'for_me' : 'all'
+      this.searchQuery = ''
+    }
+  },
+
+  savePreferences() {
+    localStorage.setItem(this.storageKey, JSON.stringify({
+      resolvedFilter: this.resolvedFilter,
+      roleFilter: this.roleFilter,
+      search: this.searchQuery,
+    }))
+  },
+
+  syncStaticInputs() {
+    this.el.querySelectorAll('[data-comment-status-value]').forEach(r => { r.checked = r.dataset.commentStatusValue === this.resolvedFilter })
+    this.el.querySelectorAll('[data-comment-role-value]').forEach(r => { r.checked = r.dataset.commentRoleValue === this.roleFilter })
+
+    const statusLabels = { 'unresolved': 'Unresolved', 'resolved': 'Resolved', 'all': 'All comments' }
+    const statusLabelEl = this.el.querySelector('[data-comment-status-label]')
+    if (statusLabelEl) statusLabelEl.textContent = statusLabels[this.resolvedFilter] || 'Status'
+
+    const roleLabels = { 'for_me': 'For me', 'by_me': 'By me', 'all': 'For anyone' }
+    const roleLabelEl = this.el.querySelector('[data-comment-role-label]')
+    if (roleLabelEl) roleLabelEl.textContent = roleLabels[this.roleFilter] || 'Role'
+  },
+
+  syncButtonStates() {
+    this.el.querySelectorAll('[data-comment-status-active]').forEach(dot => dot.classList.toggle('hidden', this.resolvedFilter === 'all'))
+    this.el.querySelectorAll('[data-comment-role-active]').forEach(dot => dot.classList.toggle('hidden', this.roleFilter === 'all'))
+  },
+
+  filterComments() {
+    const query = this.searchQuery || ''
+
+    this.el.querySelectorAll('[data-comment-wrapper]').forEach(wrapper => {
+      const item = wrapper.querySelector('[data-comment-item]')
+      if (!item) return
+
+      const ok =
+        (!query ||
+          (item.dataset.body || '').toLowerCase().includes(query)) &&
+        (this.resolvedFilter === 'all' ||
+          (this.resolvedFilter === 'resolved' && item.dataset.resolved === 'true') ||
+          (this.resolvedFilter === 'unresolved' && item.dataset.resolved === 'false')) &&
+        (this.roleFilter === 'all' ||
+          (this.roleFilter === 'for_me' && item.dataset.forMe === 'true') ||
+          (this.roleFilter === 'by_me' && item.dataset.byMe === 'true'))
 
       wrapper.classList.toggle('hidden', !ok)
     })

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -534,6 +534,16 @@ Hooks.FeatureToggle = {
   }
 }
 
+Hooks.BuildCommitRepos = {
+  mounted() {
+    this.handleEvent('build-commit-repos-updated', ({ repos }) => {
+      const formData = new FormData()
+      repos.forEach(r => formData.append('repos[]', r))
+      fetch('/api/build_commit_repos', { method: 'post', body: formData })
+    })
+  }
+}
+
 let liveSocket = new LiveSocket("/live", Socket, {
   params: { _csrf_token: csrfToken },
   hooks: Hooks,

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -534,6 +534,36 @@ Hooks.FeatureToggle = {
   }
 }
 
+document.addEventListener('click', (e) => {
+  const btn = e.target.closest('[data-clipboard-copy]')
+  if (!btn) return
+  e.stopPropagation()
+  e.preventDefault()
+  const text = btn.dataset.clipboardCopy
+  const icon = btn.querySelector('i')
+  const confirm = () => {
+    if (!icon) return
+    const orig = icon.className
+    icon.className = orig.replace('fa-copy', 'fa-check').replace('fa-link', 'fa-check')
+    setTimeout(() => { icon.className = orig }, 1000)
+  }
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(text).then(confirm).catch(() => fallbackCopy(text, confirm))
+  } else {
+    fallbackCopy(text, confirm)
+  }
+}, true)
+
+function fallbackCopy(text, done) {
+  const ta = Object.assign(document.createElement('textarea'), { value: text })
+  Object.assign(ta.style, { position: 'fixed', opacity: '0' })
+  document.body.appendChild(ta)
+  ta.select()
+  document.execCommand('copy')
+  document.body.removeChild(ta)
+  done?.()
+}
+
 Hooks.BuildCommitRepos = {
   mounted() {
     this.handleEvent('build-commit-repos-updated', ({ repos }) => {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -115,19 +115,37 @@ Hooks.FeatureToggle = {
     this.el.addEventListener('change', (e) => {
       const checkbox = e.target.closest('input[type="checkbox"][phx-value-feature]')
       if (!checkbox) return
-      const feature = checkbox.getAttribute('phx-value-feature')
-      const enabled = checkbox.checked
-      const formData = new FormData()
-      formData.append('feature', feature)
-      formData.append('enabled', enabled)
-      fetch('/api/features', { method: 'post', body: formData })
+      this.saveFeature(checkbox.getAttribute('phx-value-feature'), checkbox.checked)
     })
+
+    this.el.addEventListener('click', (e) => {
+      const switchButton = e.target.closest('button[role="switch"][phx-value-feature]')
+      if (switchButton) {
+        // aria-checked reflects pre-click state; invert it for the new state
+        this.saveFeature(switchButton.getAttribute('phx-value-feature'), switchButton.getAttribute('aria-checked') !== 'true')
+        return
+      }
+      const setButton = e.target.closest('button[phx-value-feature][phx-value-enabled]')
+      if (setButton) {
+        this.saveFeature(setButton.getAttribute('phx-value-feature'), setButton.getAttribute('phx-value-enabled') === 'true')
+      }
+    })
+  },
+  saveFeature(feature, enabled) {
+    const formData = new FormData()
+    formData.append('feature', feature)
+    formData.append('enabled', enabled)
+    fetch('/api/features', { method: 'post', body: formData })
   }
 }
 
 let liveSocket = new LiveSocket("/live", Socket, {
   params: { _csrf_token: csrfToken },
   hooks: Hooks,
+})
+
+window.addEventListener('phx:feature-flags-updated', (e) => {
+  document.documentElement.classList.toggle('dark', !!e.detail.dark_theme)
 })
 
 // Show progress bar on live navigation and form submits.

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -110,6 +110,258 @@ Hooks.SetReviewedCommitCutoff = {
   }
 }
 
+Hooks.CommitSearch = {
+  storageKey: 'remit:commit_filters',
+
+  mounted() {
+    this.loadPreferences()
+
+    const searchInput = this.el.querySelector('[data-commit-search]')
+    if (searchInput) {
+      if (this.searchQuery) searchInput.value = this.searchQuery
+      searchInput.addEventListener('input', (e) => {
+        this.searchQuery = e.target.value.toLowerCase()
+        this.savePreferences()
+        this.filterCommits()
+      })
+    }
+
+    // Dropdown toggle via event delegation (survives LiveView updates)
+    this.el.addEventListener('click', (e) => {
+      if (e.target.closest('[data-repo-dropdown-toggle]')) {
+        e.stopPropagation()
+        this.toggleDropdown('[data-repo-dropdown-panel]', '[data-repo-dropdown-chevron]')
+        return
+      }
+      const filterToggle = e.target.closest('[data-filter-dropdown-toggle]')
+      if (filterToggle) {
+        e.stopPropagation()
+        const dropdown = filterToggle.closest('[data-filter-dropdown]')
+        const panel = dropdown?.querySelector('[data-filter-dropdown-panel]')
+        const chevron = filterToggle.querySelector('[data-filter-chevron]')
+        const isOpen = !panel?.classList.contains('hidden')
+        this.closeAllDropdowns()
+        if (!isOpen) { panel?.classList.remove('hidden'); chevron?.classList.add('rotate-180') }
+        return
+      }
+    })
+
+    // Checkbox changes via event delegation
+    this.el.addEventListener('change', (e) => {
+      const cb = e.target
+      if (!cb.matches('input[type="checkbox"]')) return
+
+      if ('projectsAll' in cb.dataset) { this.clearSet(this.selectedProjectTeams, '[data-projects-team]'); this.onFilterChange(); return }
+      if ('projectsTeam' in cb.dataset) { this.toggleInSet(this.selectedProjectTeams, cb.dataset.projectsTeam, cb.checked); this.onFilterChange(); return }
+      if ('membersAll' in cb.dataset) { this.clearSet(this.selectedMemberTeams, '[data-members-team]'); this.onFilterChange(); return }
+      if ('membersTeam' in cb.dataset) { this.toggleInSet(this.selectedMemberTeams, cb.dataset.membersTeam, cb.checked); this.onFilterChange(); return }
+    })
+
+    this._closeDropdown = (e) => {
+      if (!e.target.closest('[data-repo-dropdown]') && !e.target.closest('[data-filter-dropdown]'))
+        this.closeAllDropdowns()
+    }
+    document.addEventListener('click', this._closeDropdown)
+
+    this.buildDynamicDropdowns()
+    this.syncStaticCheckboxes()
+    this.syncButtonStates()
+    this.filterCommits()
+  },
+
+  destroyed() {
+    document.removeEventListener('click', this._closeDropdown)
+  },
+
+  updated() {
+    this.buildDynamicDropdowns()
+    this.syncStaticCheckboxes()
+    this.syncButtonStates()
+    this.filterCommits()
+  },
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  toggleDropdown(panelSel, chevronSel) {
+    const panel = this.el.querySelector(panelSel)
+    const chevron = this.el.querySelector(chevronSel)
+    const isOpen = !panel?.classList.contains('hidden')
+    this.closeAllDropdowns()
+    if (!isOpen) { panel?.classList.remove('hidden'); chevron?.classList.add('rotate-180') }
+  },
+
+  closeAllDropdowns() {
+    this.el.querySelectorAll('[data-repo-dropdown-panel], [data-filter-dropdown-panel]').forEach(p => p.classList.add('hidden'))
+    this.el.querySelectorAll('[data-repo-dropdown-chevron], [data-filter-dropdown-toggle] [data-filter-chevron]').forEach(c => c.classList.remove('rotate-180'))
+  },
+
+  clearSet(set, itemSelector) {
+    set.clear()
+    this.el.querySelectorAll(itemSelector).forEach(cb => { cb.checked = false })
+    // re-check the matching "All" checkbox
+    const allSel = itemSelector.replace('-team]', '-all]')
+    this.el.querySelectorAll(allSel).forEach(cb => { cb.checked = true })
+  },
+
+  toggleInSet(set, value, checked) {
+    checked ? set.add(value) : set.delete(value)
+  },
+
+  onFilterChange() {
+    this.savePreferences()
+    this.syncStaticCheckboxes()
+    this.syncButtonStates()
+    this.filterCommits()
+  },
+
+  // ── Persistence ────────────────────────────────────────────────────────────
+
+  loadPreferences() {
+    try {
+      const s = JSON.parse(localStorage.getItem(this.storageKey) || '{}')
+      this.selectedRepos = new Set(s.repos || [])
+      this.selectedAuthors = new Set(s.authors || [])
+      this.selectedProjectTeams = new Set(s.projectTeams || [])
+      this.selectedMemberTeams = new Set(s.memberTeams || [])
+      this.searchQuery = s.search || ''
+    } catch (_) {
+      this.selectedRepos = new Set()
+      this.selectedAuthors = new Set()
+      this.selectedProjectTeams = new Set()
+      this.selectedMemberTeams = new Set()
+      this.searchQuery = ''
+    }
+  },
+
+  savePreferences() {
+    localStorage.setItem(this.storageKey, JSON.stringify({
+      repos: [...this.selectedRepos],
+      authors: [...this.selectedAuthors],
+      projectTeams: [...this.selectedProjectTeams],
+      memberTeams: [...this.selectedMemberTeams],
+      search: this.searchQuery,
+    }))
+  },
+
+  // ── Dynamic dropdowns (built from DOM data) ────────────────────────────────
+
+  buildDynamicDropdowns() {
+    this.buildDynamicDropdown(
+      '[data-author-checkboxes]',
+      () => [...new Set(Array.from(this.el.querySelectorAll('[data-commit-item]')).flatMap(el => (el.dataset.authors || '').split(' ').filter(Boolean)))].sort(),
+      this.selectedAuthors,
+      (author, checked) => { this.toggleInSet(this.selectedAuthors, author, checked); this.onFilterChange() },
+      () => { this.selectedAuthors.clear(); this.onFilterChange() },
+      () => this.updateLabel('[data-author-label]', this.selectedAuthors, 'By')
+    )
+
+    this.buildDynamicDropdown(
+      '[data-repo-checkboxes]',
+      () => [...new Set(Array.from(this.el.querySelectorAll('[data-commit-item]')).map(el => el.dataset.repo).filter(Boolean))].sort(),
+      this.selectedRepos,
+      (repo, checked) => { this.toggleInSet(this.selectedRepos, repo, checked); this.savePreferences(); this.updateLabel('[data-repo-dropdown-label]', this.selectedRepos, 'Repo'); this.syncButtonStates(); this.filterCommits() },
+      () => { this.selectedRepos.clear(); this.savePreferences(); this.updateLabel('[data-repo-dropdown-label]', this.selectedRepos, 'Repo'); this.syncButtonStates(); this.filterCommits() },
+      () => this.updateLabel('[data-repo-dropdown-label]', this.selectedRepos, 'Repo')
+    )
+  },
+
+  buildDynamicDropdown(containerSel, getValues, set, onChange, onClear, updateLabel) {
+    const container = this.el.querySelector(containerSel)
+    if (!container) return
+
+    const values = getValues()
+    set.forEach(v => { if (!values.includes(v)) set.delete(v) })
+
+    container.innerHTML = ''
+    container.appendChild(this.makeCheckboxLabel('All', null, set.size === 0, (_, checked) => { if (checked) onClear() }))
+    values.forEach(v => container.appendChild(this.makeCheckboxLabel(v, v, set.has(v), onChange)))
+    updateLabel()
+  },
+
+  makeCheckboxLabel(text, value, checked, onChange) {
+    const label = document.createElement('label')
+    label.className = 'flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer'
+    const cb = document.createElement('input')
+    cb.type = 'checkbox'
+    cb.checked = checked
+    cb.addEventListener('change', () => {
+      if (value === null) {
+        // "All" checkbox: uncheck all siblings, keep self checked
+        label.closest('div').querySelectorAll('input').forEach(c => { c.checked = false })
+        cb.checked = true
+      }
+      onChange(value, cb.checked)
+      // Sync the All checkbox for this container
+      const allCb = label.closest('div').querySelector('input:first-child')
+      if (value !== null && allCb) allCb.checked = false
+    })
+    const span = document.createElement('span')
+    span.textContent = text
+    span.className = 'text-xs'
+    label.appendChild(cb); label.appendChild(span)
+    return label
+  },
+
+  // ── Static checkboxes (Projects/Members — pre-rendered in HTML) ───────────
+
+  syncStaticCheckboxes() {
+    this.el.querySelectorAll('[data-projects-all]').forEach(cb => { cb.checked = this.selectedProjectTeams.size === 0 })
+    this.el.querySelectorAll('[data-projects-team]').forEach(cb => { cb.checked = this.selectedProjectTeams.has(cb.dataset.projectsTeam) })
+    this.el.querySelectorAll('[data-members-all]').forEach(cb => { cb.checked = this.selectedMemberTeams.size === 0 })
+    this.el.querySelectorAll('[data-members-team]').forEach(cb => { cb.checked = this.selectedMemberTeams.has(cb.dataset.membersTeam) })
+    this.updateLabel('[data-projects-label]', this.selectedProjectTeams, 'Projects')
+    this.updateLabel('[data-members-label]', this.selectedMemberTeams, 'Members')
+  },
+
+  // ── Labels & button state ─────────────────────────────────────────────────
+
+  updateLabel(sel, set, defaultText) {
+    const el = this.el.querySelector(sel)
+    if (!el) return
+    const count = set.size
+    el.textContent = count === 0 ? defaultText : count === 1 ? [...set][0] : `${count} selected`
+  },
+
+  syncButtonStates() {
+    ;[
+      ['[data-author-active]', this.selectedAuthors],
+      ['[data-projects-active]', this.selectedProjectTeams],
+      ['[data-members-active]', this.selectedMemberTeams],
+      ['[data-repo-active]', this.selectedRepos],
+    ].forEach(([sel, set]) => {
+      this.el.querySelectorAll(sel).forEach(dot => dot.classList.toggle('hidden', set.size === 0))
+    })
+  },
+
+  // ── Filtering ─────────────────────────────────────────────────────────────
+
+  filterCommits() {
+    const query = this.searchQuery || ''
+
+    this.el.querySelectorAll('[data-commit-wrapper]').forEach(wrapper => {
+      const item = wrapper.querySelector('[data-commit-item]')
+      if (!item) return
+
+      const authors = (item.dataset.authors || '').split(' ').filter(Boolean)
+      const projectTeams = (item.dataset.projectTeams || '').split(' ').filter(Boolean)
+      const memberTeams = (item.dataset.memberTeams || '').split(' ').filter(Boolean)
+
+      const ok =
+        (!query ||
+          (item.dataset.message || '').toLowerCase().includes(query) ||
+          (item.dataset.sha || '').toLowerCase().includes(query) ||
+          (item.dataset.repo || '').toLowerCase().includes(query) ||
+          (item.dataset.authors || '').toLowerCase().includes(query)) &&
+        (this.selectedRepos.size === 0 || this.selectedRepos.has(item.dataset.repo)) &&
+        (this.selectedAuthors.size === 0 || authors.some(a => this.selectedAuthors.has(a))) &&
+        (this.selectedProjectTeams.size === 0 || projectTeams.some(t => this.selectedProjectTeams.has(t))) &&
+        (this.selectedMemberTeams.size === 0 || memberTeams.some(t => this.selectedMemberTeams.has(t)))
+
+      wrapper.classList.toggle('hidden', !ok)
+    })
+  },
+}
+
 Hooks.FeatureToggle = {
   mounted() {
     this.el.addEventListener('change', (e) => {

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -4,6 +4,7 @@ const fs = require("fs")
 const path = require("path")
 
 module.exports = {
+  darkMode: 'class',
   content: [
     "./js/**/*.js",
     "../lib/*_web.ex",
@@ -13,13 +14,16 @@ module.exports = {
     extend: {
 
       // This implements our own, more limited color palette within the broader default one. If we just want "some lightish yellow", we can just pick a default colour by feel, nevermind that we may use `-200` in one place and `-300` in another. If we do something where we care more about sticking to a limited palette, we use these.
+      // The semantic colors below are backed by CSS variables so that dark mode can redefine them without touching markup.
       //
       // Longer term we may end up replacing all the default colours, but until then it's useful to have them to fall back on.
       colors: {
-        "gray-light": colors.gray["300"],
-        "gray-mid": colors.gray["500"],
-        "gray-dark": colors.gray["600"],
-        "almost-black": colors.gray["900"],
+        "white": "var(--color-white)",
+        "gray-200": "var(--color-gray-200)",
+        "gray-light": "var(--color-gray-light)",
+        "gray-mid": "var(--color-gray-mid)",
+        "gray-dark": "var(--color-gray-dark)",
+        "almost-black": "var(--color-almost-black)",
 
         "yellow-mid": colors.yellow["600"],
 

--- a/lib/faker.ex
+++ b/lib/faker.ex
@@ -80,4 +80,26 @@ defmodule Faker do
       "Needs more cowbell."
     ])
   end
+
+  def paragraph_comment do
+    sentences = [
+      "This looks really solid to me.",
+      "I had a quick look and the logic seems sound.",
+      "Nice refactor here, much cleaner than before.",
+      "One thing I was wondering about: should we handle the edge case where the list is empty?",
+      "The naming is clear and the intent is obvious.",
+      "I think this could be extracted into a helper at some point, but for now it's fine.",
+      "Left a note on Slack about this too, just so you know.",
+      "Let me know if you want me to pair on the next step.",
+      "Happy with the direction, just minor style thing on line 3.",
+      "Good catch on the N+1 — wouldn't have noticed that.",
+      "This matches what we discussed in the standup.",
+      "I'd love to see a test for the nil case eventually.",
+      "Merging this unblocks the next step in the flow.",
+      "Super clean, ship it."
+    ]
+
+    count = Enum.random(3..4)
+    sentences |> Enum.shuffle() |> Enum.take(count) |> Enum.join(" ")
+  end
 end

--- a/lib/remit/comments.ex
+++ b/lib/remit/comments.ex
@@ -35,6 +35,12 @@ defmodule Remit.Comments do
     comment
   end
 
+  def count_by_commit_sha(shas) when is_list(shas) do
+    from(c in Comment, where: c.commit_sha in ^shas, group_by: c.commit_sha, select: {c.commit_sha, count(c.id)})
+    |> Repo.all()
+    |> Map.new()
+  end
+
   def subscribe, do: Phoenix.PubSub.subscribe(Remit.PubSub, "comments")
 
   def broadcast_change do

--- a/lib/remit/comments.ex
+++ b/lib/remit/comments.ex
@@ -49,34 +49,37 @@ defmodule Remit.Comments do
          user_filter: user_filter,
          limit: limit
        }) do
-    query =
-      from n in CommentNotification,
-        limit: ^limit,
-        join: c in assoc(n, :comment),
-        preload: [comment: {c, [:commit, :comment_notifications]}]
+    order_by = if resolved_filter == "resolved", do: [desc: :resolved_at], else: [desc: :id]
+
+    notifications_query(username, resolved_filter, user_filter)
+    |> then(fn q ->
+      from [n, c] in q, limit: ^limit, order_by: ^order_by, preload: [comment: {c, [:commit, :comment_notifications]}]
+    end)
+    |> Repo.all()
+  end
+
+  defp notifications_query(username, resolved_filter, user_filter) do
+    query = from n in CommentNotification, join: c in assoc(n, :comment)
 
     query =
       case resolved_filter do
-        "unresolved" -> from n in query, where: is_nil(n.resolved_at), order_by: [desc: :id]
-        "resolved" -> from n in query, where: not is_nil(n.resolved_at), order_by: [desc: :resolved_at]
-        "all" -> from query, order_by: [desc: :id]
+        "unresolved" -> from n in query, where: is_nil(n.resolved_at)
+        "resolved" -> from n in query, where: not is_nil(n.resolved_at)
+        "all" -> query
       end
 
-    query =
-      case {username, user_filter} do
-        {nil, _} ->
-          query
+    case {username, user_filter} do
+      {nil, _} ->
+        query
 
-        {_, "all"} ->
-          query
+      {_, "all"} ->
+        query
 
-        {_, "for_me"} ->
-          from n in query, where: fragment("LOWER(?)", n.username) == ^String.downcase(username)
+      {_, "for_me"} ->
+        from n in query, where: fragment("LOWER(?)", n.username) == ^String.downcase(username)
 
-        {_, "by_me"} ->
-          from [n, c] in query, where: fragment("LOWER(?)", c.commenter_username) == ^String.downcase(username)
-      end
-
-    Repo.all(query)
+      {_, "by_me"} ->
+        from [n, c] in query, where: fragment("LOWER(?)", c.commenter_username) == ^String.downcase(username)
+    end
   end
 end

--- a/lib/remit/commit.ex
+++ b/lib/remit/commit.ex
@@ -12,6 +12,7 @@ defmodule Remit.Commit do
     field :url, :string
     field :payload, :map
     field :unlisted, :boolean
+    field :deployed_sha, :string
 
     field :review_started_at, :utc_datetime_usec
     field :reviewed_at, :utc_datetime_usec
@@ -94,6 +95,16 @@ defmodule Remit.Commit do
   def bot?(username), do: String.ends_with?(username, "[bot]")
 
   def botless_username(username), do: String.replace_trailing(username, "[bot]", "")
+
+  @build_commit_sha_pattern ~r/^[0-9a-f]{40}(\s|$)/
+
+  def build_commit?(commit) do
+    not is_nil(commit.message) && Regex.match?(@build_commit_sha_pattern, commit.message)
+  end
+
+  def extract_deployed_sha(commit) do
+    if build_commit?(commit), do: String.slice(commit.message, 0, 40)
+  end
 
   def message_summary(commit), do: commit.message |> String.split(~r/[\r\n]/) |> hd
 

--- a/lib/remit/commits.ex
+++ b/lib/remit/commits.ex
@@ -40,7 +40,8 @@ defmodule Remit.Commits do
   def sha_exists?(sha), do: Repo.exists?(from Commit, where: [sha: ^sha])
 
   def list_deployed_shas(repos) do
-    Repo.all(from c in Commit, where: not is_nil(c.deployed_sha) and c.repo in ^repos, select: c.deployed_sha)
+    Repo.all(from c in Commit, where: not is_nil(c.deployed_sha) and c.repo in ^repos, select: {c.deployed_sha, c.url})
+    |> Map.new()
   end
 
   def delete_reviewed_older_than_days(days) when is_integer(days) do

--- a/lib/remit/commits.ex
+++ b/lib/remit/commits.ex
@@ -39,8 +39,8 @@ defmodule Remit.Commits do
 
   def sha_exists?(sha), do: Repo.exists?(from Commit, where: [sha: ^sha])
 
-  def list_deployed_shas do
-    Repo.all(from c in Commit, where: not is_nil(c.deployed_sha), select: c.deployed_sha)
+  def list_deployed_shas(repos) do
+    Repo.all(from c in Commit, where: not is_nil(c.deployed_sha) and c.repo in ^repos, select: c.deployed_sha)
   end
 
   def delete_reviewed_older_than_days(days) when is_integer(days) do

--- a/lib/remit/commits.ex
+++ b/lib/remit/commits.ex
@@ -40,8 +40,10 @@ defmodule Remit.Commits do
   def sha_exists?(sha), do: Repo.exists?(from Commit, where: [sha: ^sha])
 
   def list_deployed_shas(repos) do
-    Repo.all(from c in Commit, where: not is_nil(c.deployed_sha) and c.repo in ^repos, select: {c.deployed_sha, c.url})
-    |> Map.new()
+    Repo.all(
+      from c in Commit, where: not is_nil(c.deployed_sha) and c.repo in ^repos, select: {c.deployed_sha, c.url, c.repo}
+    )
+    |> Map.new(fn {sha, url, repo} -> {sha, %{url: url, repo: repo}} end)
   end
 
   def delete_reviewed_older_than_days(days) when is_integer(days) do

--- a/lib/remit/commits.ex
+++ b/lib/remit/commits.ex
@@ -39,6 +39,10 @@ defmodule Remit.Commits do
 
   def sha_exists?(sha), do: Repo.exists?(from Commit, where: [sha: ^sha])
 
+  def list_deployed_shas do
+    Repo.all(from c in Commit, where: not is_nil(c.deployed_sha), select: c.deployed_sha)
+  end
+
   def delete_reviewed_older_than_days(days) when is_integer(days) do
     Repo.delete_all(from c in Commit, where: c.inserted_at < ago(^days, "day"), where: not is_nil(c.reviewed_at))
   end

--- a/lib/remit/ingest_commits.ex
+++ b/lib/remit/ingest_commits.ex
@@ -47,7 +47,7 @@ defmodule Remit.IngestCommits do
          owner,
          repo
        ) do
-    %Commit{
+    commit = %Commit{
       owner: owner,
       repo: repo,
       sha: sha,
@@ -57,6 +57,8 @@ defmodule Remit.IngestCommits do
       url: url,
       payload: payload
     }
+
+    %{commit | deployed_sha: Commit.extract_deployed_sha(commit)}
   end
 
   defp usernames(author, committer, message) do

--- a/lib/remit_web/components/layouts.ex
+++ b/lib/remit_web/components/layouts.ex
@@ -7,11 +7,19 @@ defmodule RemitWeb.Layouts do
   defp tab(assigns) do
     ~H"""
     <.link patch={@url} class={tab_class(assigns)} title={@show_notification_bell && "You have unresolved comments ;)"}>
-      <i class={["fas", @icon]}></i>
+      <span class="relative inline-block">
+        <i class={["fas", @icon]}></i>
+        <%= if @notification_count && @notification_count > 0 do %>
+          <span class="inline-flex items-center justify-center absolute top-0 -right-2.5 min-w-[0.75rem] h-3 px-1 text-[8px] font-light leading-none text-red-100 dark:text-blue-100 bg-red-600 dark:bg-blue-600 rounded-full">
+            <%= @notification_count %>
+          </span>
+        <% else %>
+          <%= if @show_notification_bell do %>
+            <span class="inline-block absolute -top-0.5 -right-0.5 w-2 h-2 bg-red-600 border rounded-full"></span>
+          <% end %>
+        <% end %>
+      </span>
       <span class="tabs__tab__text"><%= @text %></span>
-      <%= if @show_notification_bell do %>
-        <span class="inline-block absolute top-2 right-2 w-2 h-2 bg-red-600 border rounded-full"></span>
-      <% end %>
     </.link>
     """
   end

--- a/lib/remit_web/components/layouts/app.html.heex
+++ b/lib/remit_web/components/layouts/app.html.heex
@@ -2,7 +2,7 @@
   <i class="fal fa-sync fa-spin mr-2"></i> Bruh, someone stole the internet!
 </div>
 
-<div class="tabs">
+<div class={["tabs", @compact_design && "tabs--compact"]}>
   <%= for tab <- @tabs do %>
     <.tab
       action={tab.action}

--- a/lib/remit_web/components/layouts/app.html.heex
+++ b/lib/remit_web/components/layouts/app.html.heex
@@ -11,6 +11,7 @@
       text={tab.text}
       icon={tab.icon}
       show_notification_bell={tab.has_notification}
+      notification_count={Map.get(tab, :notification_count)}
     />
   <% end %>
 </div>

--- a/lib/remit_web/components/layouts/root.html.heex
+++ b/lib/remit_web/components/layouts/root.html.heex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class={if (Plug.Conn.get_session(@conn, "feature_flags") || %{})["dark_theme"], do: "dark"}>
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -20,7 +20,7 @@
     </script>
     <link rel="icon" href={~p"/images/#{Application.get_env(:remit, :favicon)}"} />
   </head>
-  <body class="bg-gray-dark">
+  <body class="bg-gray-dark dark:bg-gray-900">
     <div class="mx-auto max-w-3xl min-h-screen bg-white shadow-2xl">
       <%= @inner_content %>
     </div>

--- a/lib/remit_web/controllers/user_controller.ex
+++ b/lib/remit_web/controllers/user_controller.ex
@@ -20,6 +20,18 @@ defmodule RemitWeb.UserController do
     |> json(true)
   end
 
+  def set_build_commit_repo(conn, %{"repos" => repos}) when is_list(repos) do
+    conn
+    |> put_session("build_commit_repos", repos)
+    |> json(true)
+  end
+
+  def set_build_commit_repo(conn, _params) do
+    conn
+    |> put_session("build_commit_repos", [])
+    |> json(true)
+  end
+
   def set_feature_flag(conn, %{"feature" => feature, "enabled" => enabled}) do
     stored = get_session(conn, "feature_flags") || %{}
     enabled_bool = enabled in [true, "true", "1"]

--- a/lib/remit_web/live/comment/comment_component.ex
+++ b/lib/remit_web/live/comment/comment_component.ex
@@ -18,10 +18,13 @@ defmodule RemitWeb.CommentComponent do
 
   defp comment_recipient_avatars(commit, comment, notification, opts) do
     compact = Keyword.get(opts, :compact, false)
-    avatar_opts = Keyword.delete(opts, :compact) ++ [
-      shape: if(compact, do: :hexagon, else: :default),
-      class: if(compact, do: "ring-1 ring-white dark:ring-gray-900", else: "")
-    ]
+
+    avatar_opts =
+      Keyword.delete(opts, :compact) ++
+        [
+          shape: if(compact, do: :hexagon, else: :default),
+          class: if(compact, do: "ring-1 ring-white dark:ring-gray-900", else: "")
+        ]
 
     avatars =
       comment_recipients(commit, comment, notification)

--- a/lib/remit_web/live/comment/comment_component.ex
+++ b/lib/remit_web/live/comment/comment_component.ex
@@ -2,6 +2,7 @@ defmodule RemitWeb.CommentComponent do
   @moduledoc false
   use RemitWeb, :live_component
   alias Remit.{Commit, Comment, Utils}
+  import Phoenix.HTML.Tag
 
   # We get a comment URL via webhook, but the anchor used to be incorrect for line comments.
   # It's supposed to be fixed per 2021-10-04; if we like, we could look into using it.
@@ -16,10 +17,23 @@ defmodule RemitWeb.CommentComponent do
   end
 
   defp comment_recipient_avatars(commit, comment, notification, opts) do
-    comment_recipients(commit, comment, notification)
-    |> Enum.sort()
-    |> move_element_to_front(notification.username)
-    |> Enum.map(&github_avatar(&1, :comment, opts))
+    compact = Keyword.get(opts, :compact, false)
+    avatar_opts = Keyword.delete(opts, :compact) ++ [
+      shape: if(compact, do: :hexagon, else: :default),
+      class: if(compact, do: "ring-1 ring-white dark:ring-gray-900", else: "")
+    ]
+
+    avatars =
+      comment_recipients(commit, comment, notification)
+      |> Enum.sort()
+      |> move_element_to_front(notification.username)
+      |> Enum.map(&github_avatar(&1, :comment, avatar_opts))
+
+    if compact do
+      content_tag(:span, avatars, class: "inline-flex -space-x-1.5")
+    else
+      avatars
+    end
   end
 
   # For commits authored by a group, display the entire group as a joint recipient of reviewer comments.

--- a/lib/remit_web/live/comment/comment_component.html.heex
+++ b/lib/remit_web/live/comment/comment_component.html.heex
@@ -4,56 +4,104 @@
   phx-click="selected"
   phx-value-id={@notification.id}
   phx-hook="FixLink"
-  class={"
-    comment
-    #{if @your_last_selected?, do: " comment--highlight"}
-    block no-underline my-1 bg-gray-200
-    #{if @resolved?, do: " comment--resolved"}
-  "}
+  class={[
+    "comment block no-underline",
+    if(@compact, do: "border-b border-gray-light px-3 py-2", else: "my-1 bg-gray-200 dark:bg-gray-800"),
+    if(@your_last_selected?, do: "comment--highlight"),
+    if(@resolved?, do: "comment--resolved"),
+  ]}
 >
-  <div class="comment__metadata bg-gray-400 py-1 px-3 flex items-center">
-    <div class="mr-2 min-w-0">
-      <div class="flex items-center space-x-1">
-        <%= github_avatar(@comment.commenter_username, :comment, tooltip_pos: "up-left") %>
-        <i class="fas fa-chevron-right text-gray-dark"></i>
-        <%= comment_recipient_avatars(@commit, @comment, @notification, tooltip_pos: "up-left") %>
-        <span>on <%= Utils.format_datetime(@comment.commented_at) %></span>
+  <%= if @compact do %>
+    <div class="flex items-start gap-2">
+      <%# Avatar column %>
+      <div class="flex-none flex items-center gap-1 pt-0.5">
+        <%= github_avatar(@comment.commenter_username, :comment, shape: :hexagon, tooltip_pos: "up-left") %>
+        <i class="fas fa-chevron-right text-gray-300 dark:text-gray-600 text-[8px]"></i>
+        <%= comment_recipient_avatars(@commit, @comment, @notification, tooltip_pos: "up-left", compact: @compact) %>
       </div>
-      <div class="truncate">
-        Re: <i><%= if @commit, do: Commit.message_summary(@commit), else: @comment.commit_sha %></i>
-      </div>
-    </div>
-    <div class="ml-auto whitespace-nowrap">
-      <%= if @resolved? do %>
-        <i class="fas fa-check text-green-dark"></i>
-        <span class="text-gray-dark"><%= Utils.format_datetime(@notification.resolved_at) %></span>
 
-        <%= if @at_me? do %>
-          <button phx-click="unresolve" phx-value-id={@notification.id} class="ml-2">
-            <i class="far fa-eye-slash"></i> Mark as new
-          </button>
-        <% end %>
-      <% else %>
-        <%= if @at_me? do %>
-          <%= if @resolved_coauthors != [] do %>
-            <span {tooltip_attributes("resolved by #{Enum.join(@resolved_coauthors, ", ")}", pos: "up-right")}>
-              <i class="fas fa-user-friends text-green-dark"></i>
+      <%# Content column %>
+      <div class="flex-1 min-w-0">
+        <p class="break-words text-sm leading-snug"><%= String.slice(@comment.body, 0, 1000) %></p>
+        <p class="text-xs text-gray-mid mt-0.5 truncate">
+          Re: <i><%= if @commit, do: Commit.message_summary(@commit), else: @comment.commit_sha %></i>
+          · <%= Utils.format_datetime(@comment.commented_at) %>
+        </p>
+      </div>
+
+      <%# Action column %>
+      <div class="flex-none flex items-center gap-1 self-center">
+        <%= if @resolved? do %>
+          <i class="fas fa-check text-green-dark text-xs"></i>
+          <%= if @at_me? do %>
+            <button phx-click="unresolve" phx-value-id={@notification.id} class="flex flex-col items-center gap-0.5 px-2 py-1 rounded-lg opacity-30 hover:opacity-100" title="Mark as new">
+              <i class="fas fa-undo text-sm"></i>
+              <span class="text-[9px] leading-none">Reopen</span>
+            </button>
+          <% end %>
+        <% else %>
+          <%= if @at_me? do %>
+            <%= if @resolved_coauthors != [] do %>
+              <span {tooltip_attributes("resolved by #{Enum.join(@resolved_coauthors, ", ")}", pos: "up-right")}>
+                <i class="fas fa-user-friends text-green-dark"></i>
+              </span>
+            <% end %>
+            <button phx-click="resolve" phx-value-id={@notification.id} class="flex flex-col items-center gap-0.5 px-2 py-1 rounded-lg bg-green-light dark:bg-green-900" title="Resolve">
+              <i class="fas fa-check text-green-dark dark:text-green-400 text-sm"></i>
+              <span class="text-[9px] leading-none">Resolve</span>
+            </button>
+          <% else %>
+            <span title={"Unresolved since #{Utils.format_datetime(@notification.inserted_at)}"}>
+              <i class="far fa-comment-dots text-yellow-mid"></i>
             </span>
           <% end %>
-          <button phx-click="resolve" phx-value-id={@notification.id} class="bg-green-light dark:bg-green-900">
-            <i class="fas fa-check text-green-dark dark:text-green-400"></i> Resolve
-          </button>
-        <% else %>
-          <span {tooltip_attributes("Since #{Utils.format_datetime(@notification.inserted_at)}", pos: "up-right")}>
-            <i class="fas fa-gift text-yellow-mid"></i>
-            <span class="text-gray-dark">Unresolved</span>
-          </span>
         <% end %>
-      <% end %>
+      </div>
     </div>
-  </div>
-  <p class="py-1 px-3 break-words">
-    <%= # It's nice to see the full comment, but sometimes we'll paste some code example or data output that overwhelms the UI. %>
-    <%= String.slice(@comment.body, 0, 1000) %>
-  </p>
+  <% else %>
+    <div class="comment__metadata bg-gray-400 py-1 px-3 flex items-center">
+      <div class="mr-2 min-w-0">
+        <div class="flex items-center space-x-1">
+          <%= github_avatar(@comment.commenter_username, :comment, tooltip_pos: "up-left") %>
+          <i class="fas fa-chevron-right text-gray-dark"></i>
+          <%= comment_recipient_avatars(@commit, @comment, @notification, tooltip_pos: "up-left", compact: @compact) %>
+          <span>on <%= Utils.format_datetime(@comment.commented_at) %></span>
+        </div>
+        <div class="truncate">
+          Re: <i><%= if @commit, do: Commit.message_summary(@commit), else: @comment.commit_sha %></i>
+        </div>
+      </div>
+      <div class="ml-auto whitespace-nowrap flex items-center gap-1">
+        <%= if @resolved? do %>
+          <i class="fas fa-check text-green-dark"></i>
+          <span class="text-gray-dark"><%= Utils.format_datetime(@notification.resolved_at) %></span>
+          <%= if @at_me? do %>
+            <button phx-click="unresolve" phx-value-id={@notification.id} class="ml-2">
+              <i class="far fa-eye-slash"></i> Mark as new
+            </button>
+          <% end %>
+        <% else %>
+          <%= if @at_me? do %>
+            <%= if @resolved_coauthors != [] do %>
+              <span {tooltip_attributes("resolved by #{Enum.join(@resolved_coauthors, ", ")}", pos: "up-right")}>
+                <i class="fas fa-user-friends text-green-dark"></i>
+              </span>
+            <% end %>
+            <button phx-click="resolve" phx-value-id={@notification.id} class="bg-green-light dark:bg-green-900">
+              <i class="fas fa-check text-green-dark dark:text-green-400"></i> Resolve
+            </button>
+          <% else %>
+            <span title={"Unresolved since #{Utils.format_datetime(@notification.inserted_at)}"}>
+              <i class="far fa-comment-dots text-yellow-mid"></i>
+              <span class="text-gray-dark">Unresolved</span>
+            </span>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+    <p class="py-1 px-3 break-words">
+      <%= # It's nice to see the full comment, but sometimes we'll paste some code example or data output that overwhelms the UI. %>
+      <%= String.slice(@comment.body, 0, 1000) %>
+    </p>
+  <% end %>
 </a>

--- a/lib/remit_web/live/comment/comment_component.html.heex
+++ b/lib/remit_web/live/comment/comment_component.html.heex
@@ -4,6 +4,11 @@
   phx-click="selected"
   phx-value-id={@notification.id}
   phx-hook="FixLink"
+  data-comment-item=""
+  data-resolved={if @resolved?, do: "true", else: "false"}
+  data-for-me={if @at_me?, do: "true", else: "false"}
+  data-by-me={if assigns[:by_me?], do: "true", else: "false"}
+  data-body={String.slice(@comment.body, 0, 500)}
   class={[
     "comment block no-underline",
     if(@compact, do: "border-b border-gray-light px-3 py-2", else: "my-1 bg-gray-200 dark:bg-gray-800"),
@@ -30,7 +35,6 @@
 
       <div class="flex-none flex items-center gap-1 self-center">
         <%= if @resolved? do %>
-          <i class="fas fa-check text-green-dark text-xs"></i>
           <%= if @at_me? do %>
             <button
               phx-click="unresolve"
@@ -41,6 +45,8 @@
               <i class="fas fa-undo text-sm"></i>
               <span class="text-[9px] leading-none">Reopen</span>
             </button>
+          <% else %>
+            <i class="fas fa-check text-green-dark text-xs"></i>
           <% end %>
         <% else %>
           <%= if @at_me? do %>

--- a/lib/remit_web/live/comment/comment_component.html.heex
+++ b/lib/remit_web/live/comment/comment_component.html.heex
@@ -42,11 +42,10 @@
             <button
               phx-click="unresolve"
               phx-value-id={@notification.id}
-              class="flex flex-col items-center gap-0.5 px-2 py-1 rounded-lg opacity-30 hover:opacity-100"
+              class="flex items-center justify-center w-6 h-6 rounded-md opacity-30 hover:opacity-100"
               title="Mark as new"
             >
-              <i class="fas fa-undo text-sm"></i>
-              <span class="text-[9px] leading-none">Reopen</span>
+              <i class="fas fa-undo text-xs"></i>
             </button>
           <% else %>
             <i class="fas fa-check text-green-dark text-xs"></i>
@@ -61,11 +60,10 @@
             <button
               phx-click="resolve"
               phx-value-id={@notification.id}
-              class="flex flex-col items-center gap-0.5 px-2 py-1 rounded-lg bg-green-light dark:bg-green-900"
+              class="flex items-center justify-center w-6 h-6 rounded-md bg-green-light dark:bg-green-900"
               title="Resolve"
             >
-              <i class="fas fa-check text-green-dark dark:text-green-400 text-sm"></i>
-              <span class="text-[9px] leading-none">Resolve</span>
+              <i class="fas fa-check text-green-dark dark:text-green-400 text-xs"></i>
             </button>
           <% else %>
             <span title={"Unresolved since #{Utils.format_datetime(@notification.inserted_at)}"}>
@@ -96,8 +94,8 @@
           <i class="fas fa-check text-green-dark"></i>
           <span class="text-gray-dark"><%= Utils.format_datetime(@notification.resolved_at) %></span>
           <%= if @at_me? do %>
-            <button phx-click="unresolve" phx-value-id={@notification.id} class="ml-2">
-              <i class="far fa-eye-slash"></i> Mark as new
+            <button phx-click="unresolve" phx-value-id={@notification.id} class="ml-2" title="Mark as new">
+              <i class="far fa-eye-slash"></i>
             </button>
           <% end %>
         <% else %>
@@ -107,13 +105,12 @@
                 <i class="fas fa-user-friends text-green-dark"></i>
               </span>
             <% end %>
-            <button phx-click="resolve" phx-value-id={@notification.id} class="bg-green-light dark:bg-green-900">
-              <i class="fas fa-check text-green-dark dark:text-green-400"></i> Resolve
+            <button phx-click="resolve" phx-value-id={@notification.id} class="bg-green-light dark:bg-green-900" title="Resolve">
+              <i class="fas fa-check text-green-dark dark:text-green-400"></i>
             </button>
           <% else %>
             <span title={"Unresolved since #{Utils.format_datetime(@notification.inserted_at)}"}>
               <i class="far fa-comment-dots text-yellow-mid"></i>
-              <span class="text-gray-dark">Unresolved</span>
             </span>
           <% end %>
         <% end %>

--- a/lib/remit_web/live/comment/comment_component.html.heex
+++ b/lib/remit_web/live/comment/comment_component.html.heex
@@ -31,6 +31,7 @@
           <%= if assigns[:deployed?] do %>
             <i
               class="fas fa-rocket text-[9px] text-gray-400 align-middle cursor-pointer"
+              title={"Deployed on #{assigns[:deployed_repo]}"}
               data-deployed-url={assigns[:deployed_url]}
             >
             </i>
@@ -95,6 +96,7 @@
           <%= if assigns[:deployed?] do %>
             <i
               class="fas fa-rocket text-[9px] text-gray-400 align-middle cursor-pointer"
+              title={"Deployed on #{assigns[:deployed_repo]}"}
               data-deployed-url={assigns[:deployed_url]}
             >
             </i>

--- a/lib/remit_web/live/comment/comment_component.html.heex
+++ b/lib/remit_web/live/comment/comment_component.html.heex
@@ -8,19 +8,18 @@
     "comment block no-underline",
     if(@compact, do: "border-b border-gray-light px-3 py-2", else: "my-1 bg-gray-200 dark:bg-gray-800"),
     if(@your_last_selected?, do: "comment--highlight"),
-    if(@resolved?, do: "comment--resolved"),
+    if(@resolved?, do: "comment--resolved")
   ]}
 >
   <%= if @compact do %>
     <div class="flex items-start gap-2">
-      <%# Avatar column %>
+      
       <div class="flex-none flex items-center gap-1 pt-0.5">
         <%= github_avatar(@comment.commenter_username, :comment, shape: :hexagon, tooltip_pos: "up-left") %>
         <i class="fas fa-chevron-right text-gray-300 dark:text-gray-600 text-[8px]"></i>
         <%= comment_recipient_avatars(@commit, @comment, @notification, tooltip_pos: "up-left", compact: @compact) %>
       </div>
 
-      <%# Content column %>
       <div class="flex-1 min-w-0">
         <p class="break-words text-sm leading-snug"><%= String.slice(@comment.body, 0, 1000) %></p>
         <p class="text-xs text-gray-mid mt-0.5 truncate">
@@ -29,12 +28,16 @@
         </p>
       </div>
 
-      <%# Action column %>
       <div class="flex-none flex items-center gap-1 self-center">
         <%= if @resolved? do %>
           <i class="fas fa-check text-green-dark text-xs"></i>
           <%= if @at_me? do %>
-            <button phx-click="unresolve" phx-value-id={@notification.id} class="flex flex-col items-center gap-0.5 px-2 py-1 rounded-lg opacity-30 hover:opacity-100" title="Mark as new">
+            <button
+              phx-click="unresolve"
+              phx-value-id={@notification.id}
+              class="flex flex-col items-center gap-0.5 px-2 py-1 rounded-lg opacity-30 hover:opacity-100"
+              title="Mark as new"
+            >
               <i class="fas fa-undo text-sm"></i>
               <span class="text-[9px] leading-none">Reopen</span>
             </button>
@@ -46,7 +49,12 @@
                 <i class="fas fa-user-friends text-green-dark"></i>
               </span>
             <% end %>
-            <button phx-click="resolve" phx-value-id={@notification.id} class="flex flex-col items-center gap-0.5 px-2 py-1 rounded-lg bg-green-light dark:bg-green-900" title="Resolve">
+            <button
+              phx-click="resolve"
+              phx-value-id={@notification.id}
+              class="flex flex-col items-center gap-0.5 px-2 py-1 rounded-lg bg-green-light dark:bg-green-900"
+              title="Resolve"
+            >
               <i class="fas fa-check text-green-dark dark:text-green-400 text-sm"></i>
               <span class="text-[9px] leading-none">Resolve</span>
             </button>

--- a/lib/remit_web/live/comment/comment_component.html.heex
+++ b/lib/remit_web/live/comment/comment_component.html.heex
@@ -18,7 +18,6 @@
 >
   <%= if @compact do %>
     <div class="flex items-start gap-2">
-      
       <div class="flex-none flex items-center gap-1 pt-0.5">
         <%= github_avatar(@comment.commenter_username, :comment, shape: :hexagon, tooltip_pos: "up-left") %>
         <i class="fas fa-chevron-right text-gray-300 dark:text-gray-600 text-[8px]"></i>
@@ -48,7 +47,9 @@
               <i class="fas fa-undo text-xs"></i>
             </button>
           <% else %>
-            <i class="fas fa-check text-green-dark text-xs"></i>
+            <div class="flex items-center justify-center w-6 h-6">
+              <i class="fas fa-check text-green-dark text-xs"></i>
+            </div>
           <% end %>
         <% else %>
           <%= if @at_me? do %>
@@ -66,8 +67,11 @@
               <i class="fas fa-check text-green-dark dark:text-green-400 text-xs"></i>
             </button>
           <% else %>
-            <span title={"Unresolved since #{Utils.format_datetime(@notification.inserted_at)}"}>
-              <i class="far fa-comment-dots text-yellow-mid"></i>
+            <span
+              class="flex items-center justify-center w-6 h-6"
+              title={"Unresolved since #{Utils.format_datetime(@notification.inserted_at)}"}
+            >
+              <i class="far fa-comment-dots text-yellow-mid text-xs"></i>
             </span>
           <% end %>
         <% end %>
@@ -94,8 +98,8 @@
           <i class="fas fa-check text-green-dark"></i>
           <span class="text-gray-dark"><%= Utils.format_datetime(@notification.resolved_at) %></span>
           <%= if @at_me? do %>
-            <button phx-click="unresolve" phx-value-id={@notification.id} class="ml-2" title="Mark as new">
-              <i class="far fa-eye-slash"></i>
+            <button phx-click="unresolve" phx-value-id={@notification.id} class="ml-2">
+              <i class="far fa-eye-slash"></i> Mark as new
             </button>
           <% end %>
         <% else %>
@@ -105,12 +109,13 @@
                 <i class="fas fa-user-friends text-green-dark"></i>
               </span>
             <% end %>
-            <button phx-click="resolve" phx-value-id={@notification.id} class="bg-green-light dark:bg-green-900" title="Resolve">
-              <i class="fas fa-check text-green-dark dark:text-green-400"></i>
+            <button phx-click="resolve" phx-value-id={@notification.id} class="bg-green-light dark:bg-green-900">
+              <i class="fas fa-check text-green-dark dark:text-green-400"></i> Resolve
             </button>
           <% else %>
             <span title={"Unresolved since #{Utils.format_datetime(@notification.inserted_at)}"}>
               <i class="far fa-comment-dots text-yellow-mid"></i>
+              <span class="text-gray-dark">Unresolved</span>
             </span>
           <% end %>
         <% end %>

--- a/lib/remit_web/live/comment/comment_component.html.heex
+++ b/lib/remit_web/live/comment/comment_component.html.heex
@@ -93,7 +93,11 @@
         <div class="truncate">
           Re: <i><%= if @commit, do: Commit.message_summary(@commit), else: @comment.commit_sha %></i>
           <%= if assigns[:deployed?] do %>
-            <i class="fas fa-rocket text-[9px] text-red-500 align-middle"></i>
+            <i
+              class="fas fa-rocket text-[9px] text-gray-400 align-middle cursor-pointer"
+              data-deployed-url={assigns[:deployed_url]}
+            >
+            </i>
           <% end %>
         </div>
       </div>

--- a/lib/remit_web/live/comment/comment_component.html.heex
+++ b/lib/remit_web/live/comment/comment_component.html.heex
@@ -29,6 +29,9 @@
         <p class="break-words text-sm leading-snug"><%= String.slice(@comment.body, 0, 1000) %></p>
         <p class="text-xs text-gray-mid mt-0.5 truncate">
           Re: <i><%= if @commit, do: Commit.message_summary(@commit), else: @comment.commit_sha %></i>
+          <%= if assigns[:deployed?] do %>
+            <i class="fas fa-rocket text-[9px] text-red-500 align-middle"></i>
+          <% end %>
           · <%= Utils.format_datetime(@comment.commented_at) %>
         </p>
       </div>
@@ -83,6 +86,9 @@
         </div>
         <div class="truncate">
           Re: <i><%= if @commit, do: Commit.message_summary(@commit), else: @comment.commit_sha %></i>
+          <%= if assigns[:deployed?] do %>
+            <i class="fas fa-rocket text-[9px] text-red-500 align-middle"></i>
+          <% end %>
         </div>
       </div>
       <div class="ml-auto whitespace-nowrap flex items-center gap-1">

--- a/lib/remit_web/live/comment/comment_component.html.heex
+++ b/lib/remit_web/live/comment/comment_component.html.heex
@@ -40,8 +40,8 @@
               <i class="fas fa-user-friends text-green-dark"></i>
             </span>
           <% end %>
-          <button phx-click="resolve" phx-value-id={@notification.id} class="bg-green-light">
-            <i class="fas fa-check text-green-dark"></i> Resolve
+          <button phx-click="resolve" phx-value-id={@notification.id} class="bg-green-light dark:bg-green-900">
+            <i class="fas fa-check text-green-dark dark:text-green-400"></i> Resolve
           </button>
         <% else %>
           <span {tooltip_attributes("Since #{Utils.format_datetime(@notification.inserted_at)}", pos: "up-right")}>

--- a/lib/remit_web/live/comment/comment_component.html.heex
+++ b/lib/remit_web/live/comment/comment_component.html.heex
@@ -29,7 +29,11 @@
         <p class="text-xs text-gray-mid mt-0.5 truncate">
           Re: <i><%= if @commit, do: Commit.message_summary(@commit), else: @comment.commit_sha %></i>
           <%= if assigns[:deployed?] do %>
-            <i class="fas fa-rocket text-[9px] text-red-500 align-middle"></i>
+            <i
+              class="fas fa-rocket text-[9px] text-gray-400 align-middle cursor-pointer"
+              data-deployed-url={assigns[:deployed_url]}
+            >
+            </i>
           <% end %>
           · <%= Utils.format_datetime(@comment.commented_at) %>
         </p>

--- a/lib/remit_web/live/comments/comments_live.ex
+++ b/lib/remit_web/live/comments/comments_live.ex
@@ -18,6 +18,7 @@ defmodule RemitWeb.CommentsLive do
     socket
     |> assign(your_last_selected_id: nil)
     |> assign(features: get_feature_flags(session))
+    |> assign(build_commit_repos: get_build_commit_repos(session))
     |> assign_username(github_login(session))
     |> assign_default_params(session)
     |> assign_filtered_notifications()
@@ -99,6 +100,14 @@ defmodule RemitWeb.CommentsLive do
   end
 
   @impl Phoenix.LiveView
+  def handle_info({:setting_updated, :build_commit_repos, repos}, socket) do
+    socket
+    |> assign(build_commit_repos: repos)
+    |> assign_deployed_shas()
+    |> noreply()
+  end
+
+  @impl Phoenix.LiveView
   def handle_info(message, socket) do
     Logger.error("unexpected message #{inspect(message)}")
     {:noreply, socket}
@@ -129,8 +138,10 @@ defmodule RemitWeb.CommentsLive do
   end
 
   defp assign_deployed_shas(socket) do
-    if socket.assigns.features["build_commit_status"] do
-      shas = Commits.list_deployed_shas() |> MapSet.new()
+    repos = socket.assigns.build_commit_repos
+
+    if socket.assigns.features["build_commit_status"] && repos != [] do
+      shas = Commits.list_deployed_shas(repos) |> MapSet.new()
       assign(socket, deployed_shas: shas)
     else
       assign(socket, deployed_shas: MapSet.new())

--- a/lib/remit_web/live/comments/comments_live.ex
+++ b/lib/remit_web/live/comments/comments_live.ex
@@ -141,10 +141,10 @@ defmodule RemitWeb.CommentsLive do
     repos = socket.assigns.build_commit_repos
 
     if socket.assigns.features["build_commit_status"] && repos != [] do
-      shas = Commits.list_deployed_shas(repos) |> MapSet.new()
-      assign(socket, deployed_shas: shas)
+      deployed = Commits.list_deployed_shas(repos)
+      assign(socket, deployed_shas: deployed)
     else
-      assign(socket, deployed_shas: MapSet.new())
+      assign(socket, deployed_shas: %{})
     end
   end
 

--- a/lib/remit_web/live/comments/comments_live.ex
+++ b/lib/remit_web/live/comments/comments_live.ex
@@ -1,7 +1,7 @@
 defmodule RemitWeb.CommentsLive do
   use RemitWeb, :live_view
   require Logger
-  alias Remit.{Comments, GithubAuth}
+  alias Remit.{Comments, GithubAuth, Settings}
 
   @max_comments Application.compile_env(:remit, :max_comments)
 
@@ -12,10 +12,12 @@ defmodule RemitWeb.CommentsLive do
     if connected?(socket) do
       Comments.subscribe()
       GithubAuth.subscribe(session["session_id"])
+      Settings.subscribe(session["session_id"])
     end
 
     socket
     |> assign(your_last_selected_id: nil)
+    |> assign(features: get_feature_flags(session))
     |> assign_username(github_login(session))
     |> assign_default_params(session)
     |> assign_filtered_notifications()
@@ -81,6 +83,13 @@ defmodule RemitWeb.CommentsLive do
   def handle_info(:logout, socket) do
     socket
     |> assign_username_and_update_filter(nil)
+    |> noreply()
+  end
+
+  @impl Phoenix.LiveView
+  def handle_info({:setting_updated, :feature_flags, flags}, socket) do
+    socket
+    |> assign(features: flags)
     |> noreply()
   end
 

--- a/lib/remit_web/live/comments/comments_live.ex
+++ b/lib/remit_web/live/comments/comments_live.ex
@@ -124,12 +124,19 @@ defmodule RemitWeb.CommentsLive do
   end
 
   defp assign_filtered_notifications(socket) do
+    {resolved_filter, user_filter} =
+      if socket.assigns.features["advanced_filters"] do
+        {"all", "all"}
+      else
+        {socket.assigns.is, socket.assigns.role}
+      end
+
     notifications =
       Comments.list_notifications(
         limit: @max_comments,
         username: socket.assigns.username,
-        resolved_filter: socket.assigns.is,
-        user_filter: socket.assigns.role
+        resolved_filter: resolved_filter,
+        user_filter: user_filter
       )
 
     assign(socket, notifications: notifications)

--- a/lib/remit_web/live/comments/comments_live.ex
+++ b/lib/remit_web/live/comments/comments_live.ex
@@ -1,7 +1,7 @@
 defmodule RemitWeb.CommentsLive do
   use RemitWeb, :live_view
   require Logger
-  alias Remit.{Comments, GithubAuth, Settings}
+  alias Remit.{Comments, Commits, GithubAuth, Settings}
 
   @max_comments Application.compile_env(:remit, :max_comments)
 
@@ -21,6 +21,7 @@ defmodule RemitWeb.CommentsLive do
     |> assign_username(github_login(session))
     |> assign_default_params(session)
     |> assign_filtered_notifications()
+    |> assign_deployed_shas()
     |> ok()
   end
 
@@ -67,7 +68,10 @@ defmodule RemitWeb.CommentsLive do
   @impl Phoenix.LiveView
   def handle_info(:comments_changed, socket) do
     # We just re-load from DB; filtering in memory could get fiddly if we need to hang on to both a filtered and an unfiltered list.
-    socket = assign_filtered_notifications(socket)
+    socket =
+      socket
+      |> assign_filtered_notifications()
+      |> assign_deployed_shas()
 
     {:noreply, socket}
   end
@@ -90,6 +94,7 @@ defmodule RemitWeb.CommentsLive do
   def handle_info({:setting_updated, :feature_flags, flags}, socket) do
     socket
     |> assign(features: flags)
+    |> assign_deployed_shas()
     |> noreply()
   end
 
@@ -121,6 +126,15 @@ defmodule RemitWeb.CommentsLive do
   defp assign_username(socket, username) do
     socket
     |> assign(username: username)
+  end
+
+  defp assign_deployed_shas(socket) do
+    if socket.assigns.features["build_commit_status"] do
+      shas = Commits.list_deployed_shas() |> MapSet.new()
+      assign(socket, deployed_shas: shas)
+    else
+      assign(socket, deployed_shas: MapSet.new())
+    end
   end
 
   defp assign_filtered_notifications(socket) do

--- a/lib/remit_web/live/comments/comments_live.html.heex
+++ b/lib/remit_web/live/comments/comments_live.html.heex
@@ -1,4 +1,4 @@
-<div class="info-box">
+<div class={["info-box", @features["compact_design"] && "!mb-1"]}>
   <%= unless @username do %>
     <p>Hello, stranger! Please <.link patch={~p"/settings"}>log in</.link>.</p>
   <% end %>
@@ -40,6 +40,7 @@
       resolved?={notification.resolved_at}
       resolved_coauthors={Remit.CommentNotification.resolved_coauthors(notification)}
       your_last_selected?={@your_last_selected_id == notification.id}
+      compact={@features["compact_design"]}
     />
   <% end %>
 <% end %>

--- a/lib/remit_web/live/comments/comments_live.html.heex
+++ b/lib/remit_web/live/comments/comments_live.html.heex
@@ -136,7 +136,8 @@
           resolved_coauthors={Remit.CommentNotification.resolved_coauthors(notification)}
           your_last_selected?={@your_last_selected_id == notification.id}
           compact={@features["compact_design"]}
-          deployed?={notification.comment.commit && MapSet.member?(@deployed_shas, notification.comment.commit.sha)}
+          deployed?={notification.comment.commit && Map.has_key?(@deployed_shas, notification.comment.commit.sha)}
+          deployed_url={notification.comment.commit && Map.get(@deployed_shas, notification.comment.commit.sha)}
         />
       </div>
     <% end %>

--- a/lib/remit_web/live/comments/comments_live.html.heex
+++ b/lib/remit_web/live/comments/comments_live.html.heex
@@ -143,7 +143,8 @@
           your_last_selected?={@your_last_selected_id == notification.id}
           compact={@features["compact_design"]}
           deployed?={notification.comment.commit && Map.has_key?(@deployed_shas, notification.comment.commit.sha)}
-          deployed_url={notification.comment.commit && Map.get(@deployed_shas, notification.comment.commit.sha)}
+          deployed_url={notification.comment.commit && @deployed_shas[notification.comment.commit.sha][:url]}
+          deployed_repo={notification.comment.commit && @deployed_shas[notification.comment.commit.sha][:repo]}
         />
       </div>
     <% end %>

--- a/lib/remit_web/live/comments/comments_live.html.heex
+++ b/lib/remit_web/live/comments/comments_live.html.heex
@@ -1,25 +1,40 @@
 <div id="comment-search-area" phx-hook="CommentSearch" data-username={@username || ""}>
   <%= if @features["advanced_filters"] do %>
-    <div class={["bg-gray-100 dark:bg-gray-800 mb-4 text-sm mx-2", @features["compact_design"] && "!mb-1 rounded-xl shadow-sm"]}>
+    <div class={[
+      "bg-gray-100 dark:bg-gray-800 mb-4 text-sm mx-2",
+      @features["compact_design"] && "!mb-1 rounded-xl shadow-sm"
+    ]}>
       <div class="flex flex-wrap justify-center items-center gap-x-5 gap-y-1.5 px-3 py-2">
         <%!-- Status filter --%>
         <div class="relative" data-filter-dropdown>
-          <button data-filter-dropdown-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400">
+          <button
+            data-filter-dropdown-toggle
+            class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400"
+          >
             <i class="fas fa-comment text-[10px]"></i>
             <span data-comment-status-label>Status</span>
             <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-comment-status-active></span>
             <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-filter-chevron></i>
           </button>
-          <div data-filter-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20">
+          <div
+            data-filter-dropdown-panel
+            class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20"
+          >
             <div class="py-1">
               <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
-                <input type="radio" name="comment-status-filter" data-comment-status-value="all" /><span class="text-xs">All comments</span>
+                <input type="radio" name="comment-status-filter" data-comment-status-value="all" /><span class="text-xs">
+                  All comments
+                </span>
               </label>
               <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
-                <input type="radio" name="comment-status-filter" data-comment-status-value="unresolved" /><span class="text-xs">Unresolved</span>
+                <input type="radio" name="comment-status-filter" data-comment-status-value="unresolved" /><span class="text-xs">
+                  Unresolved
+                </span>
               </label>
               <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
-                <input type="radio" name="comment-status-filter" data-comment-status-value="resolved" /><span class="text-xs">Resolved</span>
+                <input type="radio" name="comment-status-filter" data-comment-status-value="resolved" /><span class="text-xs">
+                  Resolved
+                </span>
               </label>
             </div>
           </div>
@@ -28,22 +43,34 @@
         <%!-- Role filter (only if logged in) --%>
         <%= if @username do %>
           <div class="relative" data-filter-dropdown>
-            <button data-filter-dropdown-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400">
+            <button
+              data-filter-dropdown-toggle
+              class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400"
+            >
               <i class="fas fa-at text-[10px]"></i>
               <span data-comment-role-label>Role</span>
               <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-comment-role-active></span>
               <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-filter-chevron></i>
             </button>
-            <div data-filter-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20">
+            <div
+              data-filter-dropdown-panel
+              class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20"
+            >
               <div class="py-1">
                 <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
-                  <input type="radio" name="comment-role-filter" data-comment-role-value="all" /><span class="text-xs">For anyone</span>
+                  <input type="radio" name="comment-role-filter" data-comment-role-value="all" /><span class="text-xs">
+                    For anyone
+                  </span>
                 </label>
                 <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
-                  <input type="radio" name="comment-role-filter" data-comment-role-value="for_me" /><span class="text-xs">For me</span>
+                  <input type="radio" name="comment-role-filter" data-comment-role-value="for_me" /><span class="text-xs">
+                    For me
+                  </span>
                 </label>
                 <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
-                  <input type="radio" name="comment-role-filter" data-comment-role-value="by_me" /><span class="text-xs">By me</span>
+                  <input type="radio" name="comment-role-filter" data-comment-role-value="by_me" /><span class="text-xs">
+                    By me
+                  </span>
                 </label>
               </div>
             </div>
@@ -51,7 +78,8 @@
         <% end %>
 
         <div class="relative">
-          <i class="fas fa-search absolute left-2 top-1/2 -translate-y-1/2 text-gray-400 text-[10px] pointer-events-none"></i>
+          <i class="fas fa-search absolute left-2 top-1/2 -translate-y-1/2 text-gray-400 text-[10px] pointer-events-none">
+          </i>
           <input
             type="search"
             placeholder="Search…"

--- a/lib/remit_web/live/comments/comments_live.html.heex
+++ b/lib/remit_web/live/comments/comments_live.html.heex
@@ -108,6 +108,7 @@
           resolved_coauthors={Remit.CommentNotification.resolved_coauthors(notification)}
           your_last_selected?={@your_last_selected_id == notification.id}
           compact={@features["compact_design"]}
+          deployed?={notification.comment.commit && MapSet.member?(@deployed_shas, notification.comment.commit.sha)}
         />
       </div>
     <% end %>

--- a/lib/remit_web/live/comments/comments_live.html.heex
+++ b/lib/remit_web/live/comments/comments_live.html.heex
@@ -22,17 +22,20 @@
           >
             <div class="py-1">
               <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
-                <input type="radio" name="comment-status-filter" data-comment-status-value="all" /><span class="text-xs">
+                <input type="radio" name="comment-status-filter" data-comment-status-value="all" />
+                <span class="text-xs">
                   All comments
                 </span>
               </label>
               <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
-                <input type="radio" name="comment-status-filter" data-comment-status-value="unresolved" /><span class="text-xs">
+                <input type="radio" name="comment-status-filter" data-comment-status-value="unresolved" />
+                <span class="text-xs">
                   Unresolved
                 </span>
               </label>
               <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
-                <input type="radio" name="comment-status-filter" data-comment-status-value="resolved" /><span class="text-xs">
+                <input type="radio" name="comment-status-filter" data-comment-status-value="resolved" />
+                <span class="text-xs">
                   Resolved
                 </span>
               </label>
@@ -58,17 +61,20 @@
             >
               <div class="py-1">
                 <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
-                  <input type="radio" name="comment-role-filter" data-comment-role-value="all" /><span class="text-xs">
+                  <input type="radio" name="comment-role-filter" data-comment-role-value="all" />
+                  <span class="text-xs">
                     For anyone
                   </span>
                 </label>
                 <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
-                  <input type="radio" name="comment-role-filter" data-comment-role-value="for_me" /><span class="text-xs">
+                  <input type="radio" name="comment-role-filter" data-comment-role-value="for_me" />
+                  <span class="text-xs">
                     For me
                   </span>
                 </label>
                 <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
-                  <input type="radio" name="comment-role-filter" data-comment-role-value="by_me" /><span class="text-xs">
+                  <input type="radio" name="comment-role-filter" data-comment-role-value="by_me" />
+                  <span class="text-xs">
                     By me
                   </span>
                 </label>

--- a/lib/remit_web/live/comments/comments_live.html.heex
+++ b/lib/remit_web/live/comments/comments_live.html.heex
@@ -1,23 +1,24 @@
 <div id="comment-search-area" phx-hook="CommentSearch" data-username={@username || ""}>
   <%= if @features["advanced_filters"] do %>
-    <div class={["bg-gray-200 mb-4 text-sm mx-2", @features["compact_design"] && "!mb-1 rounded-2xl shadow-sm"]}>
-      <div class="flex flex-wrap items-center gap-x-5 gap-y-1.5 px-3 py-2">
+    <div class={["bg-gray-100 dark:bg-gray-800 mb-4 text-sm mx-2", @features["compact_design"] && "!mb-1 rounded-xl shadow-sm"]}>
+      <div class="flex flex-wrap justify-center items-center gap-x-5 gap-y-1.5 px-3 py-2">
         <%!-- Status filter --%>
         <div class="relative" data-filter-dropdown>
           <button data-filter-dropdown-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400">
+            <i class="fas fa-comment text-[10px]"></i>
             <span data-comment-status-label>Status</span>
             <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-comment-status-active></span>
             <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-filter-chevron></i>
           </button>
           <div data-filter-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20">
             <div class="py-1">
-              <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+              <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
                 <input type="radio" name="comment-status-filter" data-comment-status-value="all" /><span class="text-xs">All comments</span>
               </label>
-              <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+              <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
                 <input type="radio" name="comment-status-filter" data-comment-status-value="unresolved" /><span class="text-xs">Unresolved</span>
               </label>
-              <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+              <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
                 <input type="radio" name="comment-status-filter" data-comment-status-value="resolved" /><span class="text-xs">Resolved</span>
               </label>
             </div>
@@ -28,19 +29,20 @@
         <%= if @username do %>
           <div class="relative" data-filter-dropdown>
             <button data-filter-dropdown-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400">
+              <i class="fas fa-at text-[10px]"></i>
               <span data-comment-role-label>Role</span>
               <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-comment-role-active></span>
               <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-filter-chevron></i>
             </button>
             <div data-filter-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20">
               <div class="py-1">
-                <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
                   <input type="radio" name="comment-role-filter" data-comment-role-value="all" /><span class="text-xs">For anyone</span>
                 </label>
-                <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
                   <input type="radio" name="comment-role-filter" data-comment-role-value="for_me" /><span class="text-xs">For me</span>
                 </label>
-                <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
                   <input type="radio" name="comment-role-filter" data-comment-role-value="by_me" /><span class="text-xs">By me</span>
                 </label>
               </div>
@@ -48,13 +50,13 @@
           </div>
         <% end %>
 
-        <%!-- Search pushed to the right --%>
-        <div class="ml-auto">
+        <div class="relative">
+          <i class="fas fa-search absolute left-2 top-1/2 -translate-y-1/2 text-gray-400 text-[10px] pointer-events-none"></i>
           <input
             type="search"
             placeholder="Search…"
             data-comment-search
-            class="w-24 px-2 py-0.5 text-xs border border-gray-light rounded bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+            class="w-24 pl-5 pr-2 py-0.5 text-xs border border-gray-light rounded bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
           />
         </div>
       </div>

--- a/lib/remit_web/live/comments/comments_live.html.heex
+++ b/lib/remit_web/live/comments/comments_live.html.heex
@@ -1,46 +1,113 @@
-<div class={["info-box", @features["compact_design"] && "!mb-1"]}>
-  <%= unless @username do %>
-    <p>Hello, stranger! Please <.link patch={~p"/settings"}>log in</.link>.</p>
+<div id="comment-search-area" phx-hook="CommentSearch" data-username={@username || ""}>
+  <%= if @features["advanced_filters"] do %>
+    <div class={["bg-gray-200 mb-4 text-sm mx-2", @features["compact_design"] && "!mb-1 rounded-2xl shadow-sm"]}>
+      <div class="flex flex-wrap items-center gap-x-5 gap-y-1.5 px-3 py-2">
+        <%!-- Status filter --%>
+        <div class="relative" data-filter-dropdown>
+          <button data-filter-dropdown-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400">
+            <span data-comment-status-label>Status</span>
+            <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-comment-status-active></span>
+            <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-filter-chevron></i>
+          </button>
+          <div data-filter-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20">
+            <div class="py-1">
+              <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                <input type="radio" name="comment-status-filter" data-comment-status-value="all" /><span class="text-xs">All comments</span>
+              </label>
+              <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                <input type="radio" name="comment-status-filter" data-comment-status-value="unresolved" /><span class="text-xs">Unresolved</span>
+              </label>
+              <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                <input type="radio" name="comment-status-filter" data-comment-status-value="resolved" /><span class="text-xs">Resolved</span>
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <%!-- Role filter (only if logged in) --%>
+        <%= if @username do %>
+          <div class="relative" data-filter-dropdown>
+            <button data-filter-dropdown-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400">
+              <span data-comment-role-label>Role</span>
+              <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-comment-role-active></span>
+              <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-filter-chevron></i>
+            </button>
+            <div data-filter-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20">
+              <div class="py-1">
+                <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                  <input type="radio" name="comment-role-filter" data-comment-role-value="all" /><span class="text-xs">For anyone</span>
+                </label>
+                <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                  <input type="radio" name="comment-role-filter" data-comment-role-value="for_me" /><span class="text-xs">For me</span>
+                </label>
+                <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                  <input type="radio" name="comment-role-filter" data-comment-role-value="by_me" /><span class="text-xs">By me</span>
+                </label>
+              </div>
+            </div>
+          </div>
+        <% end %>
+
+        <%!-- Search pushed to the right --%>
+        <div class="ml-auto">
+          <input
+            type="search"
+            placeholder="Search…"
+            data-comment-search
+            class="w-24 px-2 py-0.5 text-xs border border-gray-light rounded bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+          />
+        </div>
+      </div>
+    </div>
+  <% else %>
+    <div class={["info-box", @features["compact_design"] && "!mb-1"]}>
+      <%= unless @username do %>
+        <p>Hello, stranger! Please <.link patch={~p"/settings"}>log in</.link>.</p>
+      <% end %>
+
+      <p>
+        <%= filter_link(@socket, assigns, :comments, "filter-comment-unresolved", "Unresolved", is: "unresolved") %> · <%= filter_link(
+          @socket,
+          assigns,
+          :comments,
+          "filter-comment-resolved",
+          "Resolved",
+          is: "resolved"
+        ) %> · <%= filter_link(@socket, assigns, :comments, "filter-comment-all", "All comments", is: "all") %>
+      </p>
+      <%= if @username do %>
+        <p>
+          <%= filter_link(@socket, assigns, :comments, "filter-comment-for-me", "For me", role: "for_me") %> · <%= filter_link(
+            @socket,
+            assigns,
+            :comments,
+            "filter-comment-by-me",
+            "By me",
+            role: "by_me"
+          ) %> · <%= filter_link(@socket, assigns, :comments, "filter-comment-by-all", "For anyone", role: "all") %>
+        </p>
+      <% end %>
+    </div>
   <% end %>
 
-  <p>
-    <%= filter_link(@socket, assigns, :comments, "filter-comment-unresolved", "Unresolved", is: "unresolved") %> · <%= filter_link(
-      @socket,
-      assigns,
-      :comments,
-      "filter-comment-resolved",
-      "Resolved",
-      is: "resolved"
-    ) %> · <%= filter_link(@socket, assigns, :comments, "filter-comment-all", "All comments", is: "all") %>
-  </p>
-  <%= if @username do %>
-    <p>
-      <%= filter_link(@socket, assigns, :comments, "filter-comment-for-me", "For me", role: "for_me") %> · <%= filter_link(
-        @socket,
-        assigns,
-        :comments,
-        "filter-comment-by-me",
-        "By me",
-        role: "by_me"
-      ) %> · <%= filter_link(@socket, assigns, :comments, "filter-comment-by-all", "For anyone", role: "all") %>
-    </p>
+  <%= if @notifications == [] do %>
+    <RemitWeb.NoContentComponent.render />
+  <% else %>
+    <%= for notification <- @notifications do %>
+      <div data-comment-wrapper>
+        <RemitWeb.CommentComponent.render
+          id={notification.id}
+          notification={notification}
+          comment={notification.comment}
+          commit={notification.comment.commit}
+          at_me?={@username && String.downcase(notification.username) == String.downcase(@username)}
+          by_me?={@username && String.downcase(notification.comment.commenter_username) == String.downcase(@username)}
+          resolved?={notification.resolved_at}
+          resolved_coauthors={Remit.CommentNotification.resolved_coauthors(notification)}
+          your_last_selected?={@your_last_selected_id == notification.id}
+          compact={@features["compact_design"]}
+        />
+      </div>
+    <% end %>
   <% end %>
 </div>
-
-<%= if @notifications == [] do %>
-  <RemitWeb.NoContentComponent.render />
-<% else %>
-  <%= for notification <- @notifications do %>
-    <RemitWeb.CommentComponent.render
-      id={notification.id}
-      notification={notification}
-      comment={notification.comment}
-      commit={notification.comment.commit}
-      at_me?={@username && String.downcase(notification.username) == String.downcase(@username)}
-      resolved?={notification.resolved_at}
-      resolved_coauthors={Remit.CommentNotification.resolved_coauthors(notification)}
-      your_last_selected?={@your_last_selected_id == notification.id}
-      compact={@features["compact_design"]}
-    />
-  <% end %>
-<% end %>

--- a/lib/remit_web/live/commit/commit_component.html.heex
+++ b/lib/remit_web/live/commit/commit_component.html.heex
@@ -70,7 +70,7 @@
         <%= if assigns[:deployed?] do %>
           <i
             class="fas fa-rocket text-[9px] text-gray-400 align-middle ml-1 cursor-pointer"
-            title="Deployed to production"
+            title={"Deployed on #{assigns[:deployed_repo]}"}
             data-deployed-url={assigns[:deployed_url]}
           >
           </i>
@@ -103,20 +103,32 @@
         <%= if @commit.sha do %>
           <button
             type="button"
-            class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center w-6 h-6 rounded-md text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+            class={[
+              "opacity-0 group-hover:opacity-100 transition-opacity text-gray-400",
+              if(@compact,
+                do:
+                  "flex items-center justify-center w-6 h-6 rounded-md border-transparent bg-transparent hover:bg-gray-100 dark:hover:bg-gray-700"
+              )
+            ]}
             title="Copy SHA"
             data-clipboard-copy={String.slice(@commit.sha, 0, 8)}
           >
-            <i class="fas fa-copy text-xs"></i>
+            <i class={["fas fa-copy", if(@compact, do: "text-xs")]}></i>
           </button>
         <% end %>
         <button
           type="button"
-          class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center w-6 h-6 rounded-md text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+          class={[
+            "opacity-0 group-hover:opacity-100 transition-opacity text-gray-400",
+            if(@compact,
+              do:
+                "flex items-center justify-center w-6 h-6 rounded-md border-transparent bg-transparent hover:bg-gray-100 dark:hover:bg-gray-700"
+            )
+          ]}
           title="Copy link"
           data-clipboard-copy={@commit.url}
         >
-          <i class="fas fa-link text-xs"></i>
+          <i class={["fas fa-link", if(@compact, do: "text-xs")]}></i>
         </button>
       </div>
     <% end %>

--- a/lib/remit_web/live/commit/commit_component.html.heex
+++ b/lib/remit_web/live/commit/commit_component.html.heex
@@ -61,7 +61,7 @@
       </div>
     <% end %>
     <div class={"
-      flex-1 leading-snug
+      flex-1 #{if @compact, do: "leading-tight", else: "leading-snug"}
       #{if @reviewed? || @you_authored?, do: " truncate", else: " min-w-0 break-words"}
       #{if @you_authored?, do: " opacity-50"}
     "}>

--- a/lib/remit_web/live/commit/commit_component.html.heex
+++ b/lib/remit_web/live/commit/commit_component.html.heex
@@ -68,7 +68,12 @@
       <p class={if @reviewed? || @you_authored?, do: "inline", else: "mb-1"}>
         <%= Commit.message_summary(@commit) %>
         <%= if assigns[:deployed?] do %>
-          <i class="fas fa-rocket text-[9px] text-gray-400 align-middle ml-1" title="Deployed to production"></i>
+          <i
+            class="fas fa-rocket text-[9px] text-gray-400 align-middle ml-1 cursor-pointer"
+            title="Deployed to production"
+            data-deployed-url={assigns[:deployed_url]}
+          >
+          </i>
         <% end %>
         <%= if assigns[:comment_count] && assigns[:comment_count] > 0 do %>
           <span

--- a/lib/remit_web/live/commit/commit_component.html.heex
+++ b/lib/remit_web/live/commit/commit_component.html.heex
@@ -66,6 +66,9 @@
     "}>
       <p class={if @reviewed? || @you_authored?, do: "inline", else: "mb-1"}>
         <%= Commit.message_summary(@commit) %>
+        <%= if assigns[:deployed?] do %>
+          <i class="fas fa-rocket text-[9px] text-red-500 align-middle ml-1"></i>
+        <% end %>
         <%= if assigns[:comment_count] && assigns[:comment_count] > 0 do %>
           <span class="inline-flex items-center gap-0.5 text-[10px] text-gray-400 dark:text-gray-500 align-middle ml-1" title={"#{assigns[:comment_count]} comment#{if assigns[:comment_count] != 1, do: "s"}"}>
             <i class="far fa-comment"></i>

--- a/lib/remit_web/live/commit/commit_component.html.heex
+++ b/lib/remit_web/live/commit/commit_component.html.heex
@@ -66,11 +66,14 @@
     "}>
       <p class={if @reviewed? || @you_authored?, do: "inline", else: "mb-1"}>
         <%= Commit.message_summary(@commit) %>
-<%= if assigns[:deployed?] do %>
+        <%= if assigns[:deployed?] do %>
           <i class="fas fa-rocket text-[9px] text-gray-400 align-middle ml-1" title="Deployed to production"></i>
         <% end %>
         <%= if assigns[:comment_count] && assigns[:comment_count] > 0 do %>
-          <span class="inline-flex items-center gap-0.5 text-[10px] text-gray-400 dark:text-gray-500 align-middle ml-1" title={"#{assigns[:comment_count]} comment#{if assigns[:comment_count] != 1, do: "s"}"}>
+          <span
+            class="inline-flex items-center gap-0.5 text-[10px] text-gray-400 dark:text-gray-500 align-middle ml-1"
+            title={"#{assigns[:comment_count]} comment#{if assigns[:comment_count] != 1, do: "s"}"}
+          >
             <i class="far fa-comment"></i>
             <%= assigns[:comment_count] %>
           </span>
@@ -150,10 +153,10 @@
                 <i class="fas fa-eye text-yellow-mid dark:text-blue-400 text-xs"></i>
               </button>
             <% true -> %>
-                <%= github_avatar(@commit.reviewed_by_username, 18,
-                  shape: :hexagon,
-                  tooltip_pos: "up-right"
-                ) %>
+              <%= github_avatar(@commit.reviewed_by_username, 18,
+                shape: :hexagon,
+                tooltip_pos: "up-right"
+              ) %>
           <% end %>
         </div>
       <% else %>
@@ -161,21 +164,20 @@
           <%= cond do %>
             <% @reviewed? && @you_authored? -> %>
             <% @reviewed? && !@you_authored? && @username -> %>
-              <button phx-click="mark_unreviewed" phx-value-id={@commit.id} class="opacity-25 hover:opacity-100" title="Mark as new">
-                <i class="far fa-eye-slash"></i>
+              <button phx-click="mark_unreviewed" phx-value-id={@commit.id} class="opacity-25 hover:opacity-100">
+                <i class="far fa-eye-slash"></i> Mark as new
               </button>
             <% @being_reviewed? && @you_are_reviewing? -> %>
-              <button phx-click="mark_reviewed" phx-value-id={@commit.id} class="bg-green-light dark:bg-green-900" title="Mark as reviewed">
-                <i class="fas fa-check text-green-dark dark:text-green-400"></i>
+              <button phx-click="mark_reviewed" phx-value-id={@commit.id} class="bg-green-light dark:bg-green-900">
+                <i class="fas fa-check text-green-dark dark:text-green-400"></i> Mark as reviewed
               </button>
             <% !@you_authored? && @username && @can_review? -> %>
               <button
                 phx-click="start_review"
                 phx-value-id={@commit.id}
                 class="hover:bg-yellow-100 hover:border-yellow-mid dark:hover:bg-blue-900 dark:hover:border-blue-700"
-                title="Start review"
               >
-                <i class="fas fa-eye text-yellow-mid dark:text-blue-400"></i>
+                <i class="fas fa-eye text-yellow-mid dark:text-blue-400"></i> Start review
               </button>
             <% true -> %>
           <% end %>

--- a/lib/remit_web/live/commit/commit_component.html.heex
+++ b/lib/remit_web/live/commit/commit_component.html.heex
@@ -1,4 +1,4 @@
-<div>
+<div data-commit-wrapper>
   <%= if @commit.date_separator_before do %>
     <%= if @compact do %>
       <div class="flex items-center gap-3 px-3 py-1.5">
@@ -21,6 +21,13 @@
     phx-click="selected"
     phx-value-id={@commit.id}
     phx-hook="FixLink"
+    data-commit-item=""
+    data-message={Commit.message_summary(@commit)}
+    data-sha={@commit.sha}
+    data-repo={@commit.repo}
+    data-authors={Enum.join(@commit.usernames, " ")}
+    data-project-teams={assigns[:project_teams] || ""}
+    data-member-teams={assigns[:member_teams] || ""}
     class={"
       flex items-center no-underline
       border-b border-gray-light

--- a/lib/remit_web/live/commit/commit_component.html.heex
+++ b/lib/remit_web/live/commit/commit_component.html.heex
@@ -33,7 +33,7 @@
       flex items-center no-underline
       border-b border-gray-light
       py-2 px-3
-      #{if @reviewed?, do: " commit--reviewed text-gray-500 dark:text-gray-600 dark:bg-green-900/40"}
+      #{if @reviewed?, do: " commit--reviewed text-gray-500 dark:text-gray-600 dark:!bg-transparent"}
       #{if @being_reviewed?, do: " commit--being-reviewed"}
       #{if @your_last_selected_commit?, do: " commit--highlight"}
     "}
@@ -64,7 +64,7 @@
       #{if @reviewed? || @you_authored?, do: " truncate", else: " min-w-0 break-words"}
       #{if @you_authored?, do: " opacity-50"}
     "}>
-      <p class={if @reviewed? || @you_authored?, do: "truncate mb-0.5", else: "mb-1"}>
+      <p class={if @reviewed? || @you_authored?, do: "inline", else: "mb-1"}>
         <%= Commit.message_summary(@commit) %>
         <%= if assigns[:comment_count] && assigns[:comment_count] > 0 do %>
           <span class="inline-flex items-center gap-0.5 text-[10px] text-gray-400 dark:text-gray-500 align-middle ml-1" title={"#{assigns[:comment_count]} comment#{if assigns[:comment_count] != 1, do: "s"}"}>
@@ -73,7 +73,7 @@
           </span>
         <% end %>
       </p>
-      <p class={if @reviewed? || @you_authored?, do: "truncate", else: ""}>
+      <p class={if @reviewed? || @you_authored?, do: "inline", else: ""}>
         <%= if @commit.usernames == [] && !@reviewed? do %>
           <RemitWeb.NoUsernameComponent.render />
         <% end %>
@@ -108,24 +108,18 @@
             <% @reviewed? && @you_authored? -> %>
               <%= github_avatar(@commit.reviewed_by_username, :small_commit, shape: :hexagon, tooltip_pos: "up-right") %>
             <% @reviewed? && !@you_authored? && @username -> %>
-              <div class="relative">
-                <button
-                  phx-click="mark_unreviewed"
-                  phx-value-id={@commit.id}
-                  class="flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-lg opacity-30 hover:opacity-100"
-                  title="Mark as new"
-                >
-                  <i class="fas fa-undo text-sm"></i>
-                  <span class="text-[9px] leading-none">Reopen</span>
-                </button>
-                <span class="absolute -top-1 -right-2">
-                  <%= github_avatar(@commit.reviewed_by_username, 18,
-                    shape: :hexagon,
-                    class: "ring-2 ring-white dark:ring-gray-900",
-                    tooltip_pos: "up-right"
-                  ) %>
-                </span>
-              </div>
+              <%= github_avatar(@commit.reviewed_by_username, 18,
+                shape: :hexagon,
+                tooltip_pos: "up-right"
+              ) %>
+              <button
+                phx-click="mark_unreviewed"
+                phx-value-id={@commit.id}
+                class="flex items-center justify-center w-6 h-6 rounded-md opacity-30 hover:opacity-100"
+                title="Reopen"
+              >
+                <i class="fas fa-undo text-xs"></i>
+              </button>
             <% @being_reviewed? && @you_are_reviewing? -> %>
               <button
                 phx-click="mark_reviewed"

--- a/lib/remit_web/live/commit/commit_component.html.heex
+++ b/lib/remit_web/live/commit/commit_component.html.heex
@@ -1,8 +1,18 @@
 <div>
   <%= if @commit.date_separator_before do %>
-    <h2 class="header-box">
-      <%= @commit.date_separator_before |> Utils.format_date() %>
-    </h2>
+    <%= if @compact do %>
+      <div class="flex items-center gap-3 px-3 py-1.5">
+        <div class="flex-1 h-px bg-gray-light"></div>
+        <span class="text-xs uppercase font-semibold tracking-wider text-gray-mid">
+          <%= @commit.date_separator_before |> Utils.format_date() %>
+        </span>
+        <div class="flex-1 h-px bg-gray-light"></div>
+      </div>
+    <% else %>
+      <h2 class="header-box">
+        <%= @commit.date_separator_before |> Utils.format_date() %>
+      </h2>
+    <% end %>
   <% end %>
 
   <a
@@ -15,18 +25,23 @@
       flex items-center no-underline
       border-b border-gray-light
       py-2 px-3
-      #{if @reviewed?, do: " commit--reviewed"}
+      #{if @reviewed?, do: " commit--reviewed text-gray-300 dark:text-gray-600 dark:bg-green-900/40"}
       #{if @being_reviewed?, do: " commit--being-reviewed"}
       #{if @your_last_selected_commit?, do: " commit--highlight"}
     "}
   >
     <%= if @commit.usernames != [] do %>
-      <div class="flex-none mr-3 flex space-x-1">
+      <div class={["flex-none mr-3 flex", if(@compact, do: "-space-x-3", else: "space-x-1"), if(@reviewed?, do: "opacity-40")]}>
         <%= for username <- @commit.usernames do %>
           <%= github_avatar(
             username,
-            if(@reviewed? || @you_authored?, do: :small_commit, else: 45),
-            class: "rounded",
+            cond do
+              @compact -> 28
+              @reviewed? || @you_authored? -> :small_commit
+              true -> 45
+            end,
+            class: if(@compact, do: "rounded ring-1 ring-white dark:ring-gray-900", else: "rounded"),
+            shape: if(@compact, do: :hexagon, else: :default),
             tooltip_pos: "up-left"
           ) %>
         <% end %>
@@ -60,49 +75,107 @@
           In review<span class="bouncy-ellipsis"><span>.</span><span>.</span><span>.</span></span>
         </span>
 
-        <%= github_avatar(@commit.review_started_by_username, :small_commit, class: "opacity-75", tooltip: nil) %>
+        <%= github_avatar(@commit.review_started_by_username, :small_commit, class: "opacity-75", shape: if(@compact, do: :hexagon, else: :default), tooltip_pos: "up-right") %>
       </div>
     <% else %>
-      <div class="flex-none ml-2 self-center">
-        <%= cond do %>
-          <% @reviewed? && @you_authored? -> %>
-          <% @reviewed? && !@you_authored? && @username -> %>
-            <button phx-click="mark_unreviewed" phx-value-id={@commit.id} class="opacity-25 hover:opacity-100">
-              <i class="far fa-eye-slash"></i> Mark as new
-            </button>
-          <% @being_reviewed? && @you_are_reviewing? -> %>
-            <button phx-click="mark_reviewed" phx-value-id={@commit.id} class="bg-green-light dark:bg-green-900">
-              <i class="fas fa-check text-green-dark dark:text-green-400"></i> Mark as reviewed
-            </button>
-          <% !@you_authored? && @username && @can_review? -> %>
-            <button
-              phx-click="start_review"
-              phx-value-id={@commit.id}
-              class="hover:bg-yellow-100 hover:border-yellow-mid dark:hover:bg-blue-900 dark:hover:border-blue-700"
-            >
-              <i class="fas fa-eye text-yellow-mid dark:text-blue-400"></i> Start review
-            </button>
-          <% true -> %>
-        <% end %>
-      </div>
+      <%= if @compact do %>
+        <div class="flex-none ml-2 flex items-center gap-1.5">
+          <%= cond do %>
+            <% @reviewed? && @you_authored? -> %>
+              <%= github_avatar(@commit.reviewed_by_username, :small_commit, shape: :hexagon, tooltip_pos: "up-right") %>
+            <% @reviewed? && !@you_authored? && @username -> %>
+              <div class="relative">
+                <button
+                  phx-click="mark_unreviewed"
+                  phx-value-id={@commit.id}
+                  class="flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-lg opacity-30 hover:opacity-100"
+                  title="Mark as new"
+                >
+                  <i class="fas fa-undo text-sm"></i>
+                  <span class="text-[9px] leading-none">Reopen</span>
+                </button>
+                <span class="absolute -top-1 -right-2">
+                  <%= github_avatar(@commit.reviewed_by_username, 18,
+                    shape: :hexagon,
+                    class: "ring-2 ring-white dark:ring-gray-900",
+                    tooltip_pos: "up-right"
+                  ) %>
+                </span>
+              </div>
+            <% @being_reviewed? && @you_are_reviewing? -> %>
+              <button
+                phx-click="mark_reviewed"
+                phx-value-id={@commit.id}
+                class="flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-lg bg-green-light dark:bg-green-900"
+                title="Mark as reviewed"
+              >
+                <i class="fas fa-check text-green-dark dark:text-green-400 text-sm"></i>
+                <span class="text-[9px] leading-none">Done</span>
+              </button>
+              <button
+                phx-click="mark_unreviewed"
+                phx-value-id={@commit.id}
+                class="flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-lg bg-red-100 dark:bg-red-900"
+                title="Cancel review"
+              >
+                <i class="fas fa-times text-red-700 dark:text-red-400 text-sm"></i>
+                <span class="text-[9px] leading-none">Cancel</span>
+              </button>
+            <% !@you_authored? && @username && @can_review? -> %>
+              <button
+                phx-click="start_review"
+                phx-value-id={@commit.id}
+                class="flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-lg hover:bg-yellow-100 hover:border-yellow-mid dark:hover:bg-blue-900 dark:hover:border-blue-700"
+                title="Start review"
+              >
+                <i class="fas fa-eye text-yellow-mid dark:text-blue-400 text-sm"></i>
+                <span class="text-[9px] leading-none">Review</span>
+              </button>
+            <% true -> %>
+          <% end %>
+        </div>
+      <% else %>
+        <div class="flex-none ml-2 self-center">
+          <%= cond do %>
+            <% @reviewed? && @you_authored? -> %>
+            <% @reviewed? && !@you_authored? && @username -> %>
+              <button phx-click="mark_unreviewed" phx-value-id={@commit.id} class="opacity-25 hover:opacity-100">
+                <i class="far fa-eye-slash"></i> Mark as new
+              </button>
+            <% @being_reviewed? && @you_are_reviewing? -> %>
+              <button phx-click="mark_reviewed" phx-value-id={@commit.id} class="bg-green-light dark:bg-green-900">
+                <i class="fas fa-check text-green-dark dark:text-green-400"></i> Mark as reviewed
+              </button>
+            <% !@you_authored? && @username && @can_review? -> %>
+              <button
+                phx-click="start_review"
+                phx-value-id={@commit.id}
+                class="hover:bg-yellow-100 hover:border-yellow-mid dark:hover:bg-blue-900 dark:hover:border-blue-700"
+              >
+                <i class="fas fa-eye text-yellow-mid dark:text-blue-400"></i> Start review
+              </button>
+            <% true -> %>
+          <% end %>
+        </div>
 
-      <div class="flex-none ml-3">
-        <%= cond do %>
-          <% @reviewed? -> %>
-            <%= github_avatar(@commit.reviewed_by_username, :small_commit, tooltip_pos: "up-right") %>
-          <% @being_reviewed? && @you_are_reviewing? -> %>
-            <button
-              phx-click="mark_unreviewed"
-              phx-value-id={@commit.id}
-              class="bg-red-100 dark:bg-red-900"
-              title="Cancel review"
-            >
-              <i class="fas fa-eye-slash text-red-700 dark:text-red-400"></i>
-            </button>
-          <% true -> %>
-            <%= github_avatar_sized_spacer(:small_commit) %>
-        <% end %>
-      </div>
+        <div class="flex-none ml-3">
+          <%= cond do %>
+            <% @reviewed? -> %>
+              <%= github_avatar(@commit.reviewed_by_username, :small_commit, tooltip_pos: "up-right") %>
+            <% @being_reviewed? && @you_are_reviewing? -> %>
+              <button
+                phx-click="mark_unreviewed"
+                phx-value-id={@commit.id}
+                class="bg-red-100 dark:bg-red-900"
+                title="Cancel review"
+              >
+                <i class="fas fa-eye-slash text-red-700 dark:text-red-400"></i>
+              </button>
+            <% true -> %>
+              <%= github_avatar_sized_spacer(:small_commit) %>
+          <% end %>
+        </div>
+      <% end %>
     <% end %>
   </a>
 </div>

--- a/lib/remit_web/live/commit/commit_component.html.heex
+++ b/lib/remit_web/live/commit/commit_component.html.heex
@@ -66,8 +66,8 @@
     "}>
       <p class={if @reviewed? || @you_authored?, do: "inline", else: "mb-1"}>
         <%= Commit.message_summary(@commit) %>
-        <%= if assigns[:deployed?] do %>
-          <i class="fas fa-rocket text-[9px] text-red-500 align-middle ml-1"></i>
+<%= if assigns[:deployed?] do %>
+          <i class="fas fa-rocket text-[9px] text-gray-400 align-middle ml-1" title="Deployed to production"></i>
         <% end %>
         <%= if assigns[:comment_count] && assigns[:comment_count] > 0 do %>
           <span class="inline-flex items-center gap-0.5 text-[10px] text-gray-400 dark:text-gray-500 align-middle ml-1" title={"#{assigns[:comment_count]} comment#{if assigns[:comment_count] != 1, do: "s"}"}>
@@ -127,32 +127,33 @@
               <button
                 phx-click="mark_reviewed"
                 phx-value-id={@commit.id}
-                class="flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-lg bg-green-light dark:bg-green-900"
+                class="flex items-center justify-center w-6 h-6 rounded-md bg-green-light dark:bg-green-900"
                 title="Mark as reviewed"
               >
-                <i class="fas fa-check text-green-dark dark:text-green-400 text-sm"></i>
-                <span class="text-[9px] leading-none">Done</span>
+                <i class="fas fa-check text-green-dark dark:text-green-400 text-xs"></i>
               </button>
               <button
                 phx-click="mark_unreviewed"
                 phx-value-id={@commit.id}
-                class="flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-lg bg-red-100 dark:bg-red-900"
+                class="flex items-center justify-center w-6 h-6 rounded-md bg-red-100 dark:bg-red-900"
                 title="Cancel review"
               >
-                <i class="fas fa-times text-red-700 dark:text-red-400 text-sm"></i>
-                <span class="text-[9px] leading-none">Cancel</span>
+                <i class="fas fa-times text-red-700 dark:text-red-400 text-xs"></i>
               </button>
             <% !@you_authored? && @username && @can_review? -> %>
               <button
                 phx-click="start_review"
                 phx-value-id={@commit.id}
-                class="flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-lg hover:bg-yellow-100 hover:border-yellow-mid dark:hover:bg-blue-900 dark:hover:border-blue-700"
+                class="flex items-center justify-center w-6 h-6 rounded-md hover:bg-yellow-100 hover:border-yellow-mid dark:hover:bg-blue-900 dark:hover:border-blue-700"
                 title="Start review"
               >
-                <i class="fas fa-eye text-yellow-mid dark:text-blue-400 text-sm"></i>
-                <span class="text-[9px] leading-none">Review</span>
+                <i class="fas fa-eye text-yellow-mid dark:text-blue-400 text-xs"></i>
               </button>
             <% true -> %>
+                <%= github_avatar(@commit.reviewed_by_username, 18,
+                  shape: :hexagon,
+                  tooltip_pos: "up-right"
+                ) %>
           <% end %>
         </div>
       <% else %>
@@ -160,20 +161,21 @@
           <%= cond do %>
             <% @reviewed? && @you_authored? -> %>
             <% @reviewed? && !@you_authored? && @username -> %>
-              <button phx-click="mark_unreviewed" phx-value-id={@commit.id} class="opacity-25 hover:opacity-100">
-                <i class="far fa-eye-slash"></i> Mark as new
+              <button phx-click="mark_unreviewed" phx-value-id={@commit.id} class="opacity-25 hover:opacity-100" title="Mark as new">
+                <i class="far fa-eye-slash"></i>
               </button>
             <% @being_reviewed? && @you_are_reviewing? -> %>
-              <button phx-click="mark_reviewed" phx-value-id={@commit.id} class="bg-green-light dark:bg-green-900">
-                <i class="fas fa-check text-green-dark dark:text-green-400"></i> Mark as reviewed
+              <button phx-click="mark_reviewed" phx-value-id={@commit.id} class="bg-green-light dark:bg-green-900" title="Mark as reviewed">
+                <i class="fas fa-check text-green-dark dark:text-green-400"></i>
               </button>
             <% !@you_authored? && @username && @can_review? -> %>
               <button
                 phx-click="start_review"
                 phx-value-id={@commit.id}
                 class="hover:bg-yellow-100 hover:border-yellow-mid dark:hover:bg-blue-900 dark:hover:border-blue-700"
+                title="Start review"
               >
-                <i class="fas fa-eye text-yellow-mid dark:text-blue-400"></i> Start review
+                <i class="fas fa-eye text-yellow-mid dark:text-blue-400"></i>
               </button>
             <% true -> %>
           <% end %>

--- a/lib/remit_web/live/commit/commit_component.html.heex
+++ b/lib/remit_web/live/commit/commit_component.html.heex
@@ -71,16 +71,16 @@
               <i class="far fa-eye-slash"></i> Mark as new
             </button>
           <% @being_reviewed? && @you_are_reviewing? -> %>
-            <button phx-click="mark_reviewed" phx-value-id={@commit.id} class="bg-green-light">
-              <i class="fas fa-check text-green-dark"></i> Mark as reviewed
+            <button phx-click="mark_reviewed" phx-value-id={@commit.id} class="bg-green-light dark:bg-green-900">
+              <i class="fas fa-check text-green-dark dark:text-green-400"></i> Mark as reviewed
             </button>
           <% !@you_authored? && @username && @can_review? -> %>
             <button
               phx-click="start_review"
               phx-value-id={@commit.id}
-              class="hover:bg-yellow-100 hover:border-yellow-mid"
+              class="hover:bg-yellow-100 hover:border-yellow-mid dark:hover:bg-blue-900 dark:hover:border-blue-700"
             >
-              <i class="fas fa-eye text-yellow-mid"></i> Start review
+              <i class="fas fa-eye text-yellow-mid dark:text-blue-400"></i> Start review
             </button>
           <% true -> %>
         <% end %>
@@ -91,8 +91,13 @@
           <% @reviewed? -> %>
             <%= github_avatar(@commit.reviewed_by_username, :small_commit, tooltip_pos: "up-right") %>
           <% @being_reviewed? && @you_are_reviewing? -> %>
-            <button phx-click="mark_unreviewed" phx-value-id={@commit.id} class="bg-red-100" title="Cancel review">
-              <i class="fas fa-eye-slash text-red-700"></i>
+            <button
+              phx-click="mark_unreviewed"
+              phx-value-id={@commit.id}
+              class="bg-red-100 dark:bg-red-900"
+              title="Cancel review"
+            >
+              <i class="fas fa-eye-slash text-red-700 dark:text-red-400"></i>
             </button>
           <% true -> %>
             <%= github_avatar_sized_spacer(:small_commit) %>

--- a/lib/remit_web/live/commit/commit_component.html.heex
+++ b/lib/remit_web/live/commit/commit_component.html.heex
@@ -31,7 +31,11 @@
     "}
   >
     <%= if @commit.usernames != [] do %>
-      <div class={["flex-none mr-3 flex", if(@compact, do: "-space-x-3", else: "space-x-1"), if(@reviewed?, do: "opacity-40")]}>
+      <div class={[
+        "flex-none mr-3 flex",
+        if(@compact, do: "-space-x-3", else: "space-x-1"),
+        if(@reviewed?, do: "opacity-40")
+      ]}>
         <%= for username <- @commit.usernames do %>
           <%= github_avatar(
             username,
@@ -75,7 +79,11 @@
           In review<span class="bouncy-ellipsis"><span>.</span><span>.</span><span>.</span></span>
         </span>
 
-        <%= github_avatar(@commit.review_started_by_username, :small_commit, class: "opacity-75", shape: if(@compact, do: :hexagon, else: :default), tooltip_pos: "up-right") %>
+        <%= github_avatar(@commit.review_started_by_username, :small_commit,
+          class: "opacity-75",
+          shape: if(@compact, do: :hexagon, else: :default),
+          tooltip_pos: "up-right"
+        ) %>
       </div>
     <% else %>
       <%= if @compact do %>

--- a/lib/remit_web/live/commit/commit_component.html.heex
+++ b/lib/remit_web/live/commit/commit_component.html.heex
@@ -28,11 +28,12 @@
     data-authors={Enum.join(@commit.usernames, " ")}
     data-project-teams={assigns[:project_teams] || ""}
     data-member-teams={assigns[:member_teams] || ""}
+    data-reviewed={if @reviewed?, do: "true", else: "false"}
     class={"
       flex items-center no-underline
       border-b border-gray-light
       py-2 px-3
-      #{if @reviewed?, do: " commit--reviewed text-gray-300 dark:text-gray-600 dark:bg-green-900/40"}
+      #{if @reviewed?, do: " commit--reviewed text-gray-500 dark:text-gray-600 dark:bg-green-900/40"}
       #{if @being_reviewed?, do: " commit--being-reviewed"}
       #{if @your_last_selected_commit?, do: " commit--highlight"}
     "}
@@ -41,7 +42,7 @@
       <div class={[
         "flex-none mr-3 flex",
         if(@compact, do: "-space-x-3", else: "space-x-1"),
-        if(@reviewed?, do: "opacity-40")
+        if(@reviewed?, do: "opacity-75 dark:opacity-40")
       ]}>
         <%= for username <- @commit.usernames do %>
           <%= github_avatar(

--- a/lib/remit_web/live/commit/commit_component.html.heex
+++ b/lib/remit_web/live/commit/commit_component.html.heex
@@ -33,6 +33,7 @@
       flex items-center no-underline
       border-b border-gray-light
       py-2 px-3
+      group
       #{if @reviewed?, do: " commit--reviewed text-gray-500 dark:text-gray-600 dark:!bg-transparent"}
       #{if @being_reviewed?, do: " commit--being-reviewed"}
       #{if @your_last_selected_commit?, do: " commit--highlight"}
@@ -91,6 +92,29 @@
         <%= Utils.format_time(@commit.committed_at) %>
       </p>
     </div>
+
+    <%= if assigns[:copy_buttons?] do %>
+      <div class="flex-none flex items-center gap-1">
+        <%= if @commit.sha do %>
+          <button
+            type="button"
+            class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center w-6 h-6 rounded-md text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+            title="Copy SHA"
+            data-clipboard-copy={String.slice(@commit.sha, 0, 8)}
+          >
+            <i class="fas fa-copy text-xs"></i>
+          </button>
+        <% end %>
+        <button
+          type="button"
+          class="opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center w-6 h-6 rounded-md text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+          title="Copy link"
+          data-clipboard-copy={@commit.url}
+        >
+          <i class="fas fa-link text-xs"></i>
+        </button>
+      </div>
+    <% end %>
 
     <%= if @being_reviewed? && !@you_are_reviewing? do %>
       <div

--- a/lib/remit_web/live/commit/commit_component.html.heex
+++ b/lib/remit_web/live/commit/commit_component.html.heex
@@ -64,8 +64,16 @@
       #{if @reviewed? || @you_authored?, do: " truncate", else: " min-w-0 break-words"}
       #{if @you_authored?, do: " opacity-50"}
     "}>
-      <p class={if @reviewed? || @you_authored?, do: "inline", else: "mb-1"}><%= Commit.message_summary(@commit) %></p>
-      <p class={if @reviewed? || @you_authored?, do: "inline", else: ""}>
+      <p class={if @reviewed? || @you_authored?, do: "truncate mb-0.5", else: "mb-1"}>
+        <%= Commit.message_summary(@commit) %>
+        <%= if assigns[:comment_count] && assigns[:comment_count] > 0 do %>
+          <span class="inline-flex items-center gap-0.5 text-[10px] text-gray-400 dark:text-gray-500 align-middle ml-1" title={"#{assigns[:comment_count]} comment#{if assigns[:comment_count] != 1, do: "s"}"}>
+            <i class="far fa-comment"></i>
+            <%= assigns[:comment_count] %>
+          </span>
+        <% end %>
+      </p>
+      <p class={if @reviewed? || @you_authored?, do: "truncate", else: ""}>
         <%= if @commit.usernames == [] && !@reviewed? do %>
           <RemitWeb.NoUsernameComponent.render />
         <% end %>

--- a/lib/remit_web/live/commits/commits_live.ex
+++ b/lib/remit_web/live/commits/commits_live.ex
@@ -89,6 +89,7 @@ defmodule RemitWeb.CommitsLive do
   def handle_info({:setting_updated, :feature_flags, flags}, socket) do
     socket
     |> assign(features: flags)
+    |> assign_comment_counts()
     |> noreply()
   end
 
@@ -126,6 +127,7 @@ defmodule RemitWeb.CommitsLive do
         socket
         |> assign_commits(Enum.slice(commits ++ commits(socket), 0, @max_commits))
         |> assign_stats()
+        |> assign_comment_counts()
         |> noreply()
     end
   end
@@ -176,6 +178,7 @@ defmodule RemitWeb.CommitsLive do
     |> assign(members_of_team: get_filter(session, "commits", "members_of_team", "all"))
     |> assign(reviewed_commit_cutoff: get_reviewed_commit_cutoff(session, %{"days" => 7, "commits" => 100}))
     |> assign(features: get_feature_flags(session))
+    |> assign(comment_counts: %{})
   end
 
   def assign_all_teams(socket) do
@@ -219,6 +222,19 @@ defmodule RemitWeb.CommitsLive do
   def assign_current_commits(socket) do
     socket
     |> assign_commits(load_commits_for_display(socket))
+    |> assign_comment_counts()
+  end
+
+  defp assign_comment_counts(socket) do
+    counts =
+      if socket.assigns.features["comment_count_badge"] do
+        shas = commits(socket) |> Enum.map(& &1.sha) |> Enum.filter(& &1)
+        Remit.Comments.count_by_commit_sha(shas)
+      else
+        %{}
+      end
+
+    assign(socket, comment_counts: counts)
   end
 
   defp assign_and_broadcast_changed_commit(socket, commit) do

--- a/lib/remit_web/live/commits/commits_live.ex
+++ b/lib/remit_web/live/commits/commits_live.ex
@@ -22,6 +22,7 @@ defmodule RemitWeb.CommitsLive do
     |> assign_defaults(session)
     |> assign_all_teams()
     |> assign_current_commits()
+    |> assign_deployed_shas()
     |> assign_stats()
     |> ok()
   end
@@ -90,6 +91,7 @@ defmodule RemitWeb.CommitsLive do
     socket
     |> assign(features: flags)
     |> assign_comment_counts()
+    |> assign_deployed_shas()
     |> noreply()
   end
 
@@ -179,6 +181,7 @@ defmodule RemitWeb.CommitsLive do
     |> assign(reviewed_commit_cutoff: get_reviewed_commit_cutoff(session, %{"days" => 7, "commits" => 100}))
     |> assign(features: get_feature_flags(session))
     |> assign(comment_counts: %{})
+    |> assign(deployed_shas: MapSet.new())
   end
 
   def assign_all_teams(socket) do
@@ -223,6 +226,15 @@ defmodule RemitWeb.CommitsLive do
     socket
     |> assign_commits(load_commits_for_display(socket))
     |> assign_comment_counts()
+  end
+
+  defp assign_deployed_shas(socket) do
+    if socket.assigns.features["build_commit_status"] do
+      shas = Commits.list_deployed_shas() |> MapSet.new()
+      assign(socket, deployed_shas: shas)
+    else
+      assign(socket, deployed_shas: MapSet.new())
+    end
   end
 
   defp assign_comment_counts(socket) do

--- a/lib/remit_web/live/commits/commits_live.ex
+++ b/lib/remit_web/live/commits/commits_live.ex
@@ -95,6 +95,13 @@ defmodule RemitWeb.CommitsLive do
     |> noreply()
   end
 
+  @impl Phoenix.LiveView
+  def handle_info({:setting_updated, :build_commit_repos, repos}, socket) do
+    socket
+    |> assign(build_commit_repos: repos)
+    |> noreply()
+  end
+
   # Receive broadcasts when other clients update their state.
   @impl Phoenix.LiveView
   def handle_info({:changed_commit, commit}, socket) do
@@ -180,6 +187,7 @@ defmodule RemitWeb.CommitsLive do
     |> assign(members_of_team: get_filter(session, "commits", "members_of_team", "all"))
     |> assign(reviewed_commit_cutoff: get_reviewed_commit_cutoff(session, %{"days" => 7, "commits" => 100}))
     |> assign(features: get_feature_flags(session))
+    |> assign(build_commit_repos: get_build_commit_repos(session))
     |> assign(comment_counts: %{})
     |> assign(deployed_shas: MapSet.new())
   end
@@ -229,8 +237,10 @@ defmodule RemitWeb.CommitsLive do
   end
 
   defp assign_deployed_shas(socket) do
-    if socket.assigns.features["build_commit_status"] do
-      shas = Commits.list_deployed_shas() |> MapSet.new()
+    repos = socket.assigns.build_commit_repos
+
+    if socket.assigns.features["build_commit_status"] && repos != [] do
+      shas = Commits.list_deployed_shas(repos) |> MapSet.new()
       assign(socket, deployed_shas: shas)
     else
       assign(socket, deployed_shas: MapSet.new())

--- a/lib/remit_web/live/commits/commits_live.ex
+++ b/lib/remit_web/live/commits/commits_live.ex
@@ -189,7 +189,7 @@ defmodule RemitWeb.CommitsLive do
     |> assign(features: get_feature_flags(session))
     |> assign(build_commit_repos: get_build_commit_repos(session))
     |> assign(comment_counts: %{})
-    |> assign(deployed_shas: MapSet.new())
+    |> assign(deployed_shas: %{})
   end
 
   def assign_all_teams(socket) do
@@ -240,10 +240,10 @@ defmodule RemitWeb.CommitsLive do
     repos = socket.assigns.build_commit_repos
 
     if socket.assigns.features["build_commit_status"] && repos != [] do
-      shas = Commits.list_deployed_shas(repos) |> MapSet.new()
-      assign(socket, deployed_shas: shas)
+      deployed = Commits.list_deployed_shas(repos)
+      assign(socket, deployed_shas: deployed)
     else
-      assign(socket, deployed_shas: MapSet.new())
+      assign(socket, deployed_shas: %{})
     end
   end
 

--- a/lib/remit_web/live/commits/commits_live.ex
+++ b/lib/remit_web/live/commits/commits_live.ex
@@ -85,6 +85,13 @@ defmodule RemitWeb.CommitsLive do
     |> noreply()
   end
 
+  @impl Phoenix.LiveView
+  def handle_info({:setting_updated, :feature_flags, flags}, socket) do
+    socket
+    |> assign(features: flags)
+    |> noreply()
+  end
+
   # Receive broadcasts when other clients update their state.
   @impl Phoenix.LiveView
   def handle_info({:changed_commit, commit}, socket) do
@@ -168,6 +175,7 @@ defmodule RemitWeb.CommitsLive do
     |> assign(projects_of_team: get_filter(session, "commits", "projects_of_team", "all"))
     |> assign(members_of_team: get_filter(session, "commits", "members_of_team", "all"))
     |> assign(reviewed_commit_cutoff: get_reviewed_commit_cutoff(session, %{"days" => 7, "commits" => 100}))
+    |> assign(features: get_feature_flags(session))
   end
 
   def assign_all_teams(socket) do

--- a/lib/remit_web/live/commits/commits_live.html.heex
+++ b/lib/remit_web/live/commits/commits_live.html.heex
@@ -100,17 +100,20 @@
           >
             <div class="py-1">
               <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
-                <input type="radio" name="commit-status-filter" data-status-value="all" /><span class="text-xs">
+                <input type="radio" name="commit-status-filter" data-status-value="all" />
+                <span class="text-xs">
                   All
                 </span>
               </label>
               <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
-                <input type="radio" name="commit-status-filter" data-status-value="unreviewed" /><span class="text-xs">
+                <input type="radio" name="commit-status-filter" data-status-value="unreviewed" />
+                <span class="text-xs">
                   Unreviewed
                 </span>
               </label>
               <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
-                <input type="radio" name="commit-status-filter" data-status-value="reviewed" /><span class="text-xs">
+                <input type="radio" name="commit-status-filter" data-status-value="reviewed" />
+                <span class="text-xs">
                   Reviewed
                 </span>
               </label>
@@ -323,7 +326,8 @@
           can_review?={can_review?(commit, @username, @teams_by_project)}
           compact={@features["compact_design"]}
           copy_buttons?={@features["copy_buttons"]}
-          deployed?={MapSet.member?(@deployed_shas, commit.sha)}
+          deployed?={Map.has_key?(@deployed_shas, commit.sha)}
+          deployed_url={Map.get(@deployed_shas, commit.sha)}
           comment_count={Map.get(@comment_counts, commit.sha, 0)}
           project_teams={Map.get(@teams_by_project, commit.repo, []) |> Enum.map(& &1.slug) |> Enum.join(" ")}
           member_teams={

--- a/lib/remit_web/live/commits/commits_live.html.heex
+++ b/lib/remit_web/live/commits/commits_live.html.heex
@@ -56,6 +56,27 @@
           </div>
         </div>
 
+        <div class="relative" data-filter-dropdown>
+          <button data-filter-dropdown-toggle data-status-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400">
+            <span data-status-label>Status</span>
+            <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-status-active></span>
+            <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-filter-chevron></i>
+          </button>
+          <div data-filter-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20">
+            <div class="py-1">
+              <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                <input type="radio" name="commit-status-filter" data-status-value="all" /><span class="text-xs">All</span>
+              </label>
+              <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                <input type="radio" name="commit-status-filter" data-status-value="unreviewed" /><span class="text-xs">Unreviewed</span>
+              </label>
+              <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                <input type="radio" name="commit-status-filter" data-status-value="reviewed" /><span class="text-xs">Reviewed</span>
+              </label>
+            </div>
+          </div>
+        </div>
+
         <%!-- Repo multi-select + search pushed to the right --%>
         <div class="flex items-center gap-2 ml-auto">
           <div class="relative" data-repo-dropdown>

--- a/lib/remit_web/live/commits/commits_live.html.heex
+++ b/lib/remit_web/live/commits/commits_live.html.heex
@@ -221,7 +221,7 @@
                 phx-value-id={@oldest_overlong_in_review_by_me.id}
                 id="for-phx-hook-complete-your-review"
                 phx-hook="ScrollToTarget"
-                class="text-blue-600 dark:text-blue-400"
+                class="text-gray-500 dark:text-gray-400"
               >
                 <i class="far fa-snooze zzz-animation"></i> Complete your review
               </a>

--- a/lib/remit_web/live/commits/commits_live.html.heex
+++ b/lib/remit_web/live/commits/commits_live.html.heex
@@ -327,7 +327,8 @@
           compact={@features["compact_design"]}
           copy_buttons?={@features["copy_buttons"]}
           deployed?={Map.has_key?(@deployed_shas, commit.sha)}
-          deployed_url={Map.get(@deployed_shas, commit.sha)}
+          deployed_url={@deployed_shas[commit.sha][:url]}
+          deployed_repo={@deployed_shas[commit.sha][:repo]}
           comment_count={Map.get(@comment_counts, commit.sha, 0)}
           project_teams={Map.get(@teams_by_project, commit.repo, []) |> Enum.map(& &1.slug) |> Enum.join(" ")}
           member_teams={

--- a/lib/remit_web/live/commits/commits_live.html.heex
+++ b/lib/remit_web/live/commits/commits_live.html.heex
@@ -266,6 +266,7 @@
         your_last_selected_commit?={@your_last_selected_commit_id == commit.id}
         can_review?={can_review?(commit, @username, @teams_by_project)}
         compact={@features["compact_design"]}
+        comment_count={Map.get(@comment_counts, commit.sha, 0)}
         project_teams={Map.get(@teams_by_project, commit.repo, []) |> Enum.map(& &1.slug) |> Enum.join(" ")}
         member_teams={@all_teams |> Enum.filter(fn t -> Enum.any?(commit.usernames, &(&1 in t.usernames)) end) |> Enum.map(& &1.slug) |> Enum.join(" ")}
       />

--- a/lib/remit_web/live/commits/commits_live.html.heex
+++ b/lib/remit_web/live/commits/commits_live.html.heex
@@ -255,7 +255,7 @@
     <% end %>
 
     <%= for commit <- @commits do %>
-      <%= unless @features["build_commit_status"] && Commit.build_commit?(commit) do %>
+      <%= unless @features["build_commit_status"] && Commit.build_commit?(commit) && commit.repo in @build_commit_repos do %>
         <RemitWeb.CommitComponent.render
           id={commit.id}
           commit={commit}

--- a/lib/remit_web/live/commits/commits_live.html.heex
+++ b/lib/remit_web/live/commits/commits_live.html.heex
@@ -1,4 +1,4 @@
-<div class="info-box">
+<div class={["info-box", @features["compact_design"] && "!mb-1"]}>
   <%= if @username do %>
     <p>
       Authored by: <%= filter_link(@socket, assigns, :commits, "filter-commit-by-author", "All",
@@ -40,69 +40,111 @@
 <%= if @commits == [] do %>
   <RemitWeb.NoContentComponent.render />
 <% else %>
-  <div class="info-box">
-    <%= if @username do %>
-      <%= if @unreviewed_count == 0 do %>
-        <p class="flex items-center justify-center text-base text-almost-black">
-          <i class="fas fa-trophy fa-lg text-yellow-mid mr-2"></i> Nothing left to review!
-        </p>
-      <% else %>
-        <p>
-          There's <b><%= @unreviewed_count %></b>
-          commit<%= if @unreviewed_count != 1, do: "s" %> to review
-          (<b><%= @others_unreviewed_count %></b> by others; <b><%= @my_unreviewed_count %></b>
-          by you).
-          <%= cond do %>
-            <% @oldest_overlong_in_review_by_me -> %>
-              <p>
-                <i class="far fa-snooze text-blue-600 zzz-animation"></i>
-                <b class="font-bold text-blue-900 ml-1">Still awake?</b>
-                Don't forget to complete
-                <a
-                  href={"#commit-#{@oldest_overlong_in_review_by_me.id}"}
-                  phx-click="selected"
-                  phx-value-id={@oldest_overlong_in_review_by_me.id}
-                  id="for-phx-hook-complete-your-review"
-                  phx-hook="ScrollToTarget"
-                >
-                  your review
-                </a>
-                :)
-              </p>
-            <% @oldest_unreviewed_for_me -> %>
-              <p>
-                Maybe do one from
-                <a
-                  href={"#commit-#{@oldest_unreviewed_for_me.id}"}
-                  phx-click="selected"
-                  phx-value-id={@oldest_unreviewed_for_me.id}
-                  id="for-phx-hook-oldest-unreviewed"
-                  phx-hook="ScrollToTarget"
-                >
-                  <%= Utils.format_datetime(@oldest_unreviewed_for_me.committed_at) %>
-                </a>
-                next.
-              </p>
-            <% true -> %>
-              <%= if @commits_of_author != @username do %>
-                <p>
-                  <i class="fas fa-trophy text-yellow-mid"></i> Nothing left for you to review!
-                </p>
-              <% end %>
-          <% end %>
-        </p>
-      <% end %>
-    <% else %>
-      <p>Hello, stranger! Please <.link patch={~p"/settings"}>log in</.link>.</p>
-      <%= if @unreviewed_count == 0 do %>
-        <p>
+  <%= if @features["compact_design"] do %>
+    <div class="flex items-center justify-center gap-3 flex-wrap px-3 py-1 mb-4 pb-3 text-xs text-gray-mid">
+      <%= if @username do %>
+        <%= if @unreviewed_count == 0 do %>
           <i class="fas fa-trophy text-yellow-mid"></i> Nothing left to review!
-        </p>
+        <% else %>
+          <span><i class="fas fa-eye mr-0.5"></i> <b class="text-almost-black"><%= @unreviewed_count %></b> to review</span>
+          <span>·</span>
+          <span><i class="fas fa-users mr-0.5"></i> <b class="text-almost-black"><%= @others_unreviewed_count %></b> by others</span>
+          <span>·</span>
+          <span><i class="fas fa-user mr-0.5"></i> <b class="text-almost-black"><%= @my_unreviewed_count %></b> by you</span>
+          <%= if @oldest_overlong_in_review_by_me do %>
+            <span>·</span>
+            <a
+              href={"#commit-#{@oldest_overlong_in_review_by_me.id}"}
+              phx-click="selected"
+              phx-value-id={@oldest_overlong_in_review_by_me.id}
+              id="for-phx-hook-complete-your-review"
+              phx-hook="ScrollToTarget"
+              class="text-blue-600 dark:text-blue-400"
+            ><i class="far fa-snooze zzz-animation"></i> Complete your review</a>
+          <% end %>
+          <%= if @oldest_unreviewed_for_me && !@oldest_overlong_in_review_by_me do %>
+            <span>·</span>
+            <a
+              href={"#commit-#{@oldest_unreviewed_for_me.id}"}
+              phx-click="selected"
+              phx-value-id={@oldest_unreviewed_for_me.id}
+              id="for-phx-hook-oldest-unreviewed"
+              phx-hook="ScrollToTarget"
+              title="Go to the oldest unreviewed"
+            >↓ <%= Utils.format_datetime(@oldest_unreviewed_for_me.committed_at) %></a>
+          <% end %>
+        <% end %>
       <% else %>
-        <p>There's <b><%= @unreviewed_count %></b> commit<%= if @unreviewed_count != 1, do: "s" %> to review.</p>
+        <span>Please <.link patch={~p"/settings"}>log in</.link></span>
+        <span>·</span>
+        <span><b><%= @unreviewed_count %></b> to review</span>
       <% end %>
-    <% end %>
-  </div>
+    </div>
+  <% else %>
+    <div class="info-box">
+      <%= if @username do %>
+        <%= if @unreviewed_count == 0 do %>
+          <p class="flex items-center justify-center text-base text-almost-black">
+            <i class="fas fa-trophy fa-lg text-yellow-mid mr-2"></i> Nothing left to review!
+          </p>
+        <% else %>
+          <p>
+            There's <b><%= @unreviewed_count %></b>
+            commit<%= if @unreviewed_count != 1, do: "s" %> to review
+            (<b><%= @others_unreviewed_count %></b> by others; <b><%= @my_unreviewed_count %></b>
+            by you).
+            <%= cond do %>
+              <% @oldest_overlong_in_review_by_me -> %>
+                <p>
+                  <i class="far fa-snooze text-blue-600 zzz-animation"></i>
+                  <b class="font-bold text-blue-900 ml-1">Still awake?</b>
+                  Don't forget to complete
+                  <a
+                    href={"#commit-#{@oldest_overlong_in_review_by_me.id}"}
+                    phx-click="selected"
+                    phx-value-id={@oldest_overlong_in_review_by_me.id}
+                    id="for-phx-hook-complete-your-review"
+                    phx-hook="ScrollToTarget"
+                  >
+                    your review
+                  </a>
+                  :)
+                </p>
+              <% @oldest_unreviewed_for_me -> %>
+                <p>
+                  Maybe do one from
+                  <a
+                    href={"#commit-#{@oldest_unreviewed_for_me.id}"}
+                    phx-click="selected"
+                    phx-value-id={@oldest_unreviewed_for_me.id}
+                    id="for-phx-hook-oldest-unreviewed"
+                    phx-hook="ScrollToTarget"
+                  >
+                    <%= Utils.format_datetime(@oldest_unreviewed_for_me.committed_at) %>
+                  </a>
+                  next.
+                </p>
+              <% true -> %>
+                <%= if @commits_of_author != @username do %>
+                  <p>
+                    <i class="fas fa-trophy text-yellow-mid"></i> Nothing left for you to review!
+                  </p>
+                <% end %>
+            <% end %>
+          </p>
+        <% end %>
+      <% else %>
+        <p>Hello, stranger! Please <.link patch={~p"/settings"}>log in</.link>.</p>
+        <%= if @unreviewed_count == 0 do %>
+          <p>
+            <i class="fas fa-trophy text-yellow-mid"></i> Nothing left to review!
+          </p>
+        <% else %>
+          <p>There's <b><%= @unreviewed_count %></b> commit<%= if @unreviewed_count != 1, do: "s" %> to review.</p>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
 
   <%= for commit <- @commits do %>
     <RemitWeb.CommitComponent.render
@@ -115,6 +157,7 @@
       you_are_reviewing?={Commit.being_reviewed_by?(commit, @username)}
       your_last_selected_commit?={@your_last_selected_commit_id == commit.id}
       can_review?={can_review?(commit, @username, @teams_by_project)}
+      compact={@features["compact_design"]}
     />
   <% end %>
 <% end %>

--- a/lib/remit_web/live/commits/commits_live.html.heex
+++ b/lib/remit_web/live/commits/commits_live.html.heex
@@ -1,11 +1,12 @@
 <div id="commit-search-area" phx-hook="CommitSearch">
   <%= if @features["advanced_filters"] do %>
-    <div class={["bg-gray-200 mb-4 text-sm mx-2", @features["compact_design"] && "!mb-1 rounded-2xl shadow-sm"]}>
-      <div class="flex flex-wrap items-center gap-x-5 gap-y-1.5 px-3 py-2">
+    <div class={["bg-gray-100 dark:bg-gray-800 mb-4 text-sm mx-2", @features["compact_design"] && "!mb-1 rounded-xl shadow-sm"]}>
+      <div class="flex flex-wrap justify-center items-center gap-x-5 gap-y-1.5 px-3 py-2">
         <%!-- Multi-select filter dropdowns --%>
         <%= if @username do %>
           <div class="relative" data-filter-dropdown>
             <button data-filter-dropdown-toggle data-author-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400">
+              <i class="fas fa-user text-[10px]"></i>
               <span data-author-label>By</span>
               <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-author-active></span>
               <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-filter-chevron></i>
@@ -18,17 +19,18 @@
 
         <div class="relative" data-filter-dropdown>
           <button data-filter-dropdown-toggle data-projects-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400">
+            <i class="fas fa-folder text-[10px]"></i>
             <span data-projects-label>Projects</span>
             <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-projects-active></span>
             <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-filter-chevron></i>
           </button>
           <div data-filter-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20 max-h-60 overflow-y-auto">
             <div class="py-1">
-              <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+              <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
                 <input type="checkbox" checked data-projects-all /><span class="text-xs">All</span>
               </label>
               <%= for team <- @all_teams do %>
-                <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
                   <input type="checkbox" data-projects-team={team.slug} /><span class="text-xs"><%= team.name %></span>
                 </label>
               <% end %>
@@ -38,17 +40,18 @@
 
         <div class="relative" data-filter-dropdown>
           <button data-filter-dropdown-toggle data-members-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400">
+            <i class="fas fa-users text-[10px]"></i>
             <span data-members-label>Members</span>
             <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-members-active></span>
             <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-filter-chevron></i>
           </button>
           <div data-filter-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20 max-h-60 overflow-y-auto">
             <div class="py-1">
-              <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+              <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
                 <input type="checkbox" checked data-members-all /><span class="text-xs">All</span>
               </label>
               <%= for team <- @all_teams do %>
-                <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
                   <input type="checkbox" data-members-team={team.slug} /><span class="text-xs"><%= team.name %></span>
                 </label>
               <% end %>
@@ -58,50 +61,51 @@
 
         <div class="relative" data-filter-dropdown>
           <button data-filter-dropdown-toggle data-status-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400">
+            <i class="fas fa-eye text-[10px]"></i>
             <span data-status-label>Status</span>
             <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-status-active></span>
             <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-filter-chevron></i>
           </button>
           <div data-filter-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20">
             <div class="py-1">
-              <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+              <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
                 <input type="radio" name="commit-status-filter" data-status-value="all" /><span class="text-xs">All</span>
               </label>
-              <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+              <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
                 <input type="radio" name="commit-status-filter" data-status-value="unreviewed" /><span class="text-xs">Unreviewed</span>
               </label>
-              <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+              <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
                 <input type="radio" name="commit-status-filter" data-status-value="reviewed" /><span class="text-xs">Reviewed</span>
               </label>
             </div>
           </div>
         </div>
 
-        <%!-- Repo multi-select + search pushed to the right --%>
-        <div class="flex items-center gap-2 ml-auto">
-          <div class="relative" data-repo-dropdown>
-            <button data-repo-dropdown-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light hover:border-gray-400 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400">
-              <i class="fas fa-code-branch text-[10px]"></i>
-              <span data-repo-dropdown-label>Repo</span>
-              <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-repo-active></span>
-              <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-repo-dropdown-chevron></i>
-            </button>
-            <div data-repo-dropdown-panel class="hidden absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20 min-w-44 max-h-60 overflow-y-auto">
-              <div data-repo-checkboxes class="py-1"></div>
-            </div>
+        <div class="relative" data-repo-dropdown>
+          <button data-repo-dropdown-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light hover:border-gray-400 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400">
+            <i class="fas fa-code-branch text-[10px]"></i>
+            <span data-repo-dropdown-label>Repo</span>
+            <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-repo-active></span>
+            <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-repo-dropdown-chevron></i>
+          </button>
+          <div data-repo-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20 min-w-44 max-h-60 overflow-y-auto">
+            <div data-repo-checkboxes class="py-1"></div>
           </div>
+        </div>
 
+        <div class="relative">
+          <i class="fas fa-search absolute left-2 top-1/2 -translate-y-1/2 text-gray-400 text-[10px] pointer-events-none"></i>
           <input
             type="search"
             placeholder="Search…"
             data-commit-search
-            class="w-24 px-2 py-0.5 text-xs border border-gray-light rounded bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+            class="w-24 pl-5 pr-2 py-0.5 text-xs border border-gray-light rounded bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
           />
         </div>
       </div>
     </div>
   <% else %>
-    <div class={["info-box", @features["compact_design"] && "!mb-1 rounded-2xl shadow-sm"]}>
+    <div class={["info-box", @features["compact_design"] && "!mb-1 rounded-xl shadow-sm"]}>
       <%= if @username do %>
         <p>
           Authored by: <%= filter_link(@socket, assigns, :commits, "filter-commit-by-author", "All",

--- a/lib/remit_web/live/commits/commits_live.html.heex
+++ b/lib/remit_web/live/commits/commits_live.html.heex
@@ -1,174 +1,249 @@
-<div class={["info-box", @features["compact_design"] && "!mb-1"]}>
-  <%= if @username do %>
-    <p>
-      Authored by: <%= filter_link(@socket, assigns, :commits, "filter-commit-by-author", "All",
-        commits_of_author: "all"
-      ) %> · <%= filter_link(
-        @socket,
-        assigns,
-        :commits,
-        "filter-commit-by-author",
-        "Me",
-        commits_of_author: @username
-      ) %>
-    </p>
-  <% end %>
-  <p>
-    In projects of team: <%= filter_link(@socket, assigns, :commits, "filter-commit-project-team-all", "All",
-      projects_of_team: "all"
-    ) %>
-    <%= for team <- @all_teams do %>
-      · <%= filter_link(@socket, assigns, :commits, "filter-commit-project-team-#{team.slug}", team.name,
-        projects_of_team: team.slug
-      ) %>
-    <% end %>
-  </p>
-  <%= if Remit.Config.has_github_org? do %>
-    <p>
-      By members of team: <%= filter_link(@socket, assigns, :commits, "filter-commit-member-team-all", "All",
-        members_of_team: "all"
-      ) %>
-      <%= for team <- @all_teams do %>
-        · <%= filter_link(@socket, assigns, :commits, "filter-commit-member-team-#{team.slug}", team.name,
-          members_of_team: team.slug
-        ) %>
-      <% end %>
-    </p>
-  <% end %>
-</div>
-
-<%= if @commits == [] do %>
-  <RemitWeb.NoContentComponent.render />
-<% else %>
-  <%= if @features["compact_design"] do %>
-    <div class="flex items-center justify-center gap-3 flex-wrap px-3 py-1 mb-4 pb-3 text-xs text-gray-mid">
-      <%= if @username do %>
-        <%= if @unreviewed_count == 0 do %>
-          <i class="fas fa-trophy text-yellow-mid"></i> Nothing left to review!
-        <% else %>
-          <span>
-            <i class="fas fa-eye mr-0.5"></i> <b class="text-almost-black"><%= @unreviewed_count %></b> to review
-          </span>
-          <span>·</span>
-          <span>
-            <i class="fas fa-users mr-0.5"></i> <b class="text-almost-black"><%= @others_unreviewed_count %></b>
-            by others
-          </span>
-          <span>·</span>
-          <span>
-            <i class="fas fa-user mr-0.5"></i> <b class="text-almost-black"><%= @my_unreviewed_count %></b> by you
-          </span>
-          <%= if @oldest_overlong_in_review_by_me do %>
-            <span>·</span>
-            <a
-              href={"#commit-#{@oldest_overlong_in_review_by_me.id}"}
-              phx-click="selected"
-              phx-value-id={@oldest_overlong_in_review_by_me.id}
-              id="for-phx-hook-complete-your-review"
-              phx-hook="ScrollToTarget"
-              class="text-blue-600 dark:text-blue-400"
-            >
-              <i class="far fa-snooze zzz-animation"></i> Complete your review
-            </a>
-          <% end %>
-          <%= if @oldest_unreviewed_for_me && !@oldest_overlong_in_review_by_me do %>
-            <span>·</span>
-            <a
-              href={"#commit-#{@oldest_unreviewed_for_me.id}"}
-              phx-click="selected"
-              phx-value-id={@oldest_unreviewed_for_me.id}
-              id="for-phx-hook-oldest-unreviewed"
-              phx-hook="ScrollToTarget"
-              title="Go to the oldest unreviewed"
-            >
-              ↓ <%= Utils.format_datetime(@oldest_unreviewed_for_me.committed_at) %>
-            </a>
-          <% end %>
+<div id="commit-search-area" phx-hook="CommitSearch">
+  <%= if @features["advanced_filters"] do %>
+    <div class={["bg-gray-200 mb-4 text-sm mx-2", @features["compact_design"] && "!mb-1 rounded-2xl shadow-sm"]}>
+      <div class="flex flex-wrap items-center gap-x-5 gap-y-1.5 px-3 py-2">
+        <%!-- Multi-select filter dropdowns --%>
+        <%= if @username do %>
+          <div class="relative" data-filter-dropdown>
+            <button data-filter-dropdown-toggle data-author-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400">
+              <span data-author-label>By</span>
+              <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-author-active></span>
+              <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-filter-chevron></i>
+            </button>
+            <div data-filter-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20 max-h-60 overflow-y-auto">
+              <div data-author-checkboxes class="py-1"></div>
+            </div>
+          </div>
         <% end %>
-      <% else %>
-        <span>Please <.link patch={~p"/settings"}>log in</.link></span>
-        <span>·</span>
-        <span><b><%= @unreviewed_count %></b> to review</span>
-      <% end %>
+
+        <div class="relative" data-filter-dropdown>
+          <button data-filter-dropdown-toggle data-projects-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400">
+            <span data-projects-label>Projects</span>
+            <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-projects-active></span>
+            <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-filter-chevron></i>
+          </button>
+          <div data-filter-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20 max-h-60 overflow-y-auto">
+            <div class="py-1">
+              <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                <input type="checkbox" checked data-projects-all /><span class="text-xs">All</span>
+              </label>
+              <%= for team <- @all_teams do %>
+                <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                  <input type="checkbox" data-projects-team={team.slug} /><span class="text-xs"><%= team.name %></span>
+                </label>
+              <% end %>
+            </div>
+          </div>
+        </div>
+
+        <div class="relative" data-filter-dropdown>
+          <button data-filter-dropdown-toggle data-members-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400">
+            <span data-members-label>Members</span>
+            <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-members-active></span>
+            <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-filter-chevron></i>
+          </button>
+          <div data-filter-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20 max-h-60 overflow-y-auto">
+            <div class="py-1">
+              <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                <input type="checkbox" checked data-members-all /><span class="text-xs">All</span>
+              </label>
+              <%= for team <- @all_teams do %>
+                <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer">
+                  <input type="checkbox" data-members-team={team.slug} /><span class="text-xs"><%= team.name %></span>
+                </label>
+              <% end %>
+            </div>
+          </div>
+        </div>
+
+        <%!-- Repo multi-select + search pushed to the right --%>
+        <div class="flex items-center gap-2 ml-auto">
+          <div class="relative" data-repo-dropdown>
+            <button data-repo-dropdown-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light hover:border-gray-400 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400">
+              <i class="fas fa-code-branch text-[10px]"></i>
+              <span data-repo-dropdown-label>Repo</span>
+              <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-repo-active></span>
+              <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-repo-dropdown-chevron></i>
+            </button>
+            <div data-repo-dropdown-panel class="hidden absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20 min-w-44 max-h-60 overflow-y-auto">
+              <div data-repo-checkboxes class="py-1"></div>
+            </div>
+          </div>
+
+          <input
+            type="search"
+            placeholder="Search…"
+            data-commit-search
+            class="w-24 px-2 py-0.5 text-xs border border-gray-light rounded bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+          />
+        </div>
+      </div>
     </div>
   <% else %>
-    <div class="info-box">
+    <div class={["info-box", @features["compact_design"] && "!mb-1 rounded-2xl shadow-sm"]}>
       <%= if @username do %>
-        <%= if @unreviewed_count == 0 do %>
-          <p class="flex items-center justify-center text-base text-almost-black">
-            <i class="fas fa-trophy fa-lg text-yellow-mid mr-2"></i> Nothing left to review!
-          </p>
-        <% else %>
-          <p>
-            There's <b><%= @unreviewed_count %></b>
-            commit<%= if @unreviewed_count != 1, do: "s" %> to review
-            (<b><%= @others_unreviewed_count %></b> by others; <b><%= @my_unreviewed_count %></b>
-            by you).
-            <%= cond do %>
-              <% @oldest_overlong_in_review_by_me -> %>
-                <p>
-                  <i class="far fa-snooze text-blue-600 zzz-animation"></i>
-                  <b class="font-bold text-blue-900 ml-1">Still awake?</b>
-                  Don't forget to complete
-                  <a
-                    href={"#commit-#{@oldest_overlong_in_review_by_me.id}"}
-                    phx-click="selected"
-                    phx-value-id={@oldest_overlong_in_review_by_me.id}
-                    id="for-phx-hook-complete-your-review"
-                    phx-hook="ScrollToTarget"
-                  >
-                    your review
-                  </a>
-                  :)
-                </p>
-              <% @oldest_unreviewed_for_me -> %>
-                <p>
-                  Maybe do one from
-                  <a
-                    href={"#commit-#{@oldest_unreviewed_for_me.id}"}
-                    phx-click="selected"
-                    phx-value-id={@oldest_unreviewed_for_me.id}
-                    id="for-phx-hook-oldest-unreviewed"
-                    phx-hook="ScrollToTarget"
-                  >
-                    <%= Utils.format_datetime(@oldest_unreviewed_for_me.committed_at) %>
-                  </a>
-                  next.
-                </p>
-              <% true -> %>
-                <%= if @commits_of_author != @username do %>
-                  <p>
-                    <i class="fas fa-trophy text-yellow-mid"></i> Nothing left for you to review!
-                  </p>
-                <% end %>
-            <% end %>
-          </p>
+        <p>
+          Authored by: <%= filter_link(@socket, assigns, :commits, "filter-commit-by-author", "All",
+            commits_of_author: "all"
+          ) %> · <%= filter_link(
+            @socket,
+            assigns,
+            :commits,
+            "filter-commit-by-author",
+            "Me",
+            commits_of_author: @username
+          ) %>
+        </p>
+      <% end %>
+      <p>
+        In projects of team: <%= filter_link(@socket, assigns, :commits, "filter-commit-project-team-all", "All",
+          projects_of_team: "all"
+        ) %>
+        <%= for team <- @all_teams do %>
+          · <%= filter_link(@socket, assigns, :commits, "filter-commit-project-team-#{team.slug}", team.name,
+            projects_of_team: team.slug
+          ) %>
         <% end %>
-      <% else %>
-        <p>Hello, stranger! Please <.link patch={~p"/settings"}>log in</.link>.</p>
-        <%= if @unreviewed_count == 0 do %>
-          <p>
-            <i class="fas fa-trophy text-yellow-mid"></i> Nothing left to review!
-          </p>
-        <% else %>
-          <p>There's <b><%= @unreviewed_count %></b> commit<%= if @unreviewed_count != 1, do: "s" %> to review.</p>
-        <% end %>
+      </p>
+      <%= if Remit.Config.has_github_org? do %>
+        <p>
+          By members of team: <%= filter_link(@socket, assigns, :commits, "filter-commit-member-team-all", "All",
+            members_of_team: "all"
+          ) %>
+          <%= for team <- @all_teams do %>
+            · <%= filter_link(@socket, assigns, :commits, "filter-commit-member-team-#{team.slug}", team.name,
+              members_of_team: team.slug
+            ) %>
+          <% end %>
+        </p>
       <% end %>
     </div>
   <% end %>
 
-  <%= for commit <- @commits do %>
-    <RemitWeb.CommitComponent.render
-      id={commit.id}
-      commit={commit}
-      username={@username}
-      being_reviewed?={commit.review_started_at && !commit.reviewed_at}
-      reviewed?={commit.reviewed_at}
-      you_authored?={Commit.authored_by?(commit, @username)}
-      you_are_reviewing?={Commit.being_reviewed_by?(commit, @username)}
-      your_last_selected_commit?={@your_last_selected_commit_id == commit.id}
-      can_review?={can_review?(commit, @username, @teams_by_project)}
-      compact={@features["compact_design"]}
-    />
+  <%= if @commits == [] do %>
+    <RemitWeb.NoContentComponent.render />
+  <% else %>
+    <%= if @features["compact_design"] do %>
+      <div class="flex items-center justify-center gap-3 flex-wrap px-3 py-1 mb-4 pb-3 text-xs text-gray-mid">
+        <%= if @username do %>
+          <%= if @unreviewed_count == 0 do %>
+            <i class="fas fa-trophy text-yellow-mid"></i> Nothing left to review!
+          <% else %>
+            <span><i class="fas fa-eye mr-0.5"></i> <b class="text-almost-black"><%= @unreviewed_count %></b> to review</span>
+            <span>·</span>
+            <span><i class="fas fa-users mr-0.5"></i> <b class="text-almost-black"><%= @others_unreviewed_count %></b> by others</span>
+            <span>·</span>
+            <span><i class="fas fa-user mr-0.5"></i> <b class="text-almost-black"><%= @my_unreviewed_count %></b> by you</span>
+            <%= if @oldest_overlong_in_review_by_me do %>
+              <span>·</span>
+              <a
+                href={"#commit-#{@oldest_overlong_in_review_by_me.id}"}
+                phx-click="selected"
+                phx-value-id={@oldest_overlong_in_review_by_me.id}
+                id="for-phx-hook-complete-your-review"
+                phx-hook="ScrollToTarget"
+                class="text-blue-600 dark:text-blue-400"
+              ><i class="far fa-snooze zzz-animation"></i> Complete your review</a>
+            <% end %>
+            <%= if @oldest_unreviewed_for_me && !@oldest_overlong_in_review_by_me do %>
+              <span>·</span>
+              <a
+                href={"#commit-#{@oldest_unreviewed_for_me.id}"}
+                phx-click="selected"
+                phx-value-id={@oldest_unreviewed_for_me.id}
+                id="for-phx-hook-oldest-unreviewed"
+                phx-hook="ScrollToTarget"
+                title="Go to the oldest unreviewed"
+              >↓ <%= Utils.format_datetime(@oldest_unreviewed_for_me.committed_at) %></a>
+            <% end %>
+          <% end %>
+        <% else %>
+          <span>Please <.link patch={~p"/settings"}>log in</.link></span>
+          <span>·</span>
+          <span><b><%= @unreviewed_count %></b> to review</span>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="info-box">
+        <%= if @username do %>
+          <%= if @unreviewed_count == 0 do %>
+            <p class="flex items-center justify-center text-base text-almost-black">
+              <i class="fas fa-trophy fa-lg text-yellow-mid mr-2"></i> Nothing left to review!
+            </p>
+          <% else %>
+            <p>
+              There's <b><%= @unreviewed_count %></b>
+              commit<%= if @unreviewed_count != 1, do: "s" %> to review
+              (<b><%= @others_unreviewed_count %></b> by others; <b><%= @my_unreviewed_count %></b>
+              by you).
+              <%= cond do %>
+                <% @oldest_overlong_in_review_by_me -> %>
+                  <p>
+                    <i class="far fa-snooze text-blue-600 zzz-animation"></i>
+                    <b class="font-bold text-blue-900 ml-1">Still awake?</b>
+                    Don't forget to complete
+                    <a
+                      href={"#commit-#{@oldest_overlong_in_review_by_me.id}"}
+                      phx-click="selected"
+                      phx-value-id={@oldest_overlong_in_review_by_me.id}
+                      id="for-phx-hook-complete-your-review"
+                      phx-hook="ScrollToTarget"
+                    >
+                      your review
+                    </a>
+                    :)
+                  </p>
+                <% @oldest_unreviewed_for_me -> %>
+                  <p>
+                    Maybe do one from
+                    <a
+                      href={"#commit-#{@oldest_unreviewed_for_me.id}"}
+                      phx-click="selected"
+                      phx-value-id={@oldest_unreviewed_for_me.id}
+                      id="for-phx-hook-oldest-unreviewed"
+                      phx-hook="ScrollToTarget"
+                    >
+                      <%= Utils.format_datetime(@oldest_unreviewed_for_me.committed_at) %>
+                    </a>
+                    next.
+                  </p>
+                <% true -> %>
+                  <%= if @commits_of_author != @username do %>
+                    <p>
+                      <i class="fas fa-trophy text-yellow-mid"></i> Nothing left for you to review!
+                    </p>
+                  <% end %>
+              <% end %>
+            </p>
+          <% end %>
+        <% else %>
+          <p>Hello, stranger! Please <.link patch={~p"/settings"}>log in</.link>.</p>
+          <%= if @unreviewed_count == 0 do %>
+            <p>
+              <i class="fas fa-trophy text-yellow-mid"></i> Nothing left to review!
+            </p>
+          <% else %>
+            <p>There's <b><%= @unreviewed_count %></b> commit<%= if @unreviewed_count != 1, do: "s" %> to review.</p>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+
+    <%= for commit <- @commits do %>
+      <RemitWeb.CommitComponent.render
+        id={commit.id}
+        commit={commit}
+        username={@username}
+        being_reviewed?={commit.review_started_at && !commit.reviewed_at}
+        reviewed?={commit.reviewed_at}
+        you_authored?={Commit.authored_by?(commit, @username)}
+        you_are_reviewing?={Commit.being_reviewed_by?(commit, @username)}
+        your_last_selected_commit?={@your_last_selected_commit_id == commit.id}
+        can_review?={can_review?(commit, @username, @teams_by_project)}
+        compact={@features["compact_design"]}
+        project_teams={Map.get(@teams_by_project, commit.repo, []) |> Enum.map(& &1.slug) |> Enum.join(" ")}
+        member_teams={@all_teams |> Enum.filter(fn t -> Enum.any?(commit.usernames, &(&1 in t.usernames)) end) |> Enum.map(& &1.slug) |> Enum.join(" ")}
+      />
+    <% end %>
   <% end %>
-<% end %>
+</div>

--- a/lib/remit_web/live/commits/commits_live.html.heex
+++ b/lib/remit_web/live/commits/commits_live.html.heex
@@ -1,30 +1,47 @@
 <div id="commit-search-area" phx-hook="CommitSearch">
   <%= if @features["advanced_filters"] do %>
-    <div class={["bg-gray-100 dark:bg-gray-800 mb-4 text-sm mx-2", @features["compact_design"] && "!mb-1 rounded-xl shadow-sm"]}>
+    <div class={[
+      "bg-gray-100 dark:bg-gray-800 mb-4 text-sm mx-2",
+      @features["compact_design"] && "!mb-1 rounded-xl shadow-sm"
+    ]}>
       <div class="flex flex-wrap justify-center items-center gap-x-5 gap-y-1.5 px-3 py-2">
         <%!-- Multi-select filter dropdowns --%>
         <%= if @username do %>
           <div class="relative" data-filter-dropdown>
-            <button data-filter-dropdown-toggle data-author-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400">
+            <button
+              data-filter-dropdown-toggle
+              data-author-toggle
+              class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400"
+            >
               <i class="fas fa-user text-[10px]"></i>
               <span data-author-label>By</span>
               <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-author-active></span>
               <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-filter-chevron></i>
             </button>
-            <div data-filter-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20 max-h-60 overflow-y-auto">
+            <div
+              data-filter-dropdown-panel
+              class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20 max-h-60 overflow-y-auto"
+            >
               <div data-author-checkboxes class="py-1"></div>
             </div>
           </div>
         <% end %>
 
         <div class="relative" data-filter-dropdown>
-          <button data-filter-dropdown-toggle data-projects-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400">
+          <button
+            data-filter-dropdown-toggle
+            data-projects-toggle
+            class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400"
+          >
             <i class="fas fa-folder text-[10px]"></i>
             <span data-projects-label>Projects</span>
             <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-projects-active></span>
             <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-filter-chevron></i>
           </button>
-          <div data-filter-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20 max-h-60 overflow-y-auto">
+          <div
+            data-filter-dropdown-panel
+            class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20 max-h-60 overflow-y-auto"
+          >
             <div class="py-1">
               <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
                 <input type="checkbox" checked data-projects-all /><span class="text-xs">All</span>
@@ -39,13 +56,20 @@
         </div>
 
         <div class="relative" data-filter-dropdown>
-          <button data-filter-dropdown-toggle data-members-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400">
+          <button
+            data-filter-dropdown-toggle
+            data-members-toggle
+            class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400"
+          >
             <i class="fas fa-users text-[10px]"></i>
             <span data-members-label>Members</span>
             <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-members-active></span>
             <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-filter-chevron></i>
           </button>
-          <div data-filter-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20 max-h-60 overflow-y-auto">
+          <div
+            data-filter-dropdown-panel
+            class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20 max-h-60 overflow-y-auto"
+          >
             <div class="py-1">
               <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
                 <input type="checkbox" checked data-members-all /><span class="text-xs">All</span>
@@ -60,41 +84,61 @@
         </div>
 
         <div class="relative" data-filter-dropdown>
-          <button data-filter-dropdown-toggle data-status-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400">
+          <button
+            data-filter-dropdown-toggle
+            data-status-toggle
+            class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:border-gray-400"
+          >
             <i class="fas fa-eye text-[10px]"></i>
             <span data-status-label>Status</span>
             <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-status-active></span>
             <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-filter-chevron></i>
           </button>
-          <div data-filter-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20">
+          <div
+            data-filter-dropdown-panel
+            class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20"
+          >
             <div class="py-1">
               <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
-                <input type="radio" name="commit-status-filter" data-status-value="all" /><span class="text-xs">All</span>
+                <input type="radio" name="commit-status-filter" data-status-value="all" /><span class="text-xs">
+                  All
+                </span>
               </label>
               <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
-                <input type="radio" name="commit-status-filter" data-status-value="unreviewed" /><span class="text-xs">Unreviewed</span>
+                <input type="radio" name="commit-status-filter" data-status-value="unreviewed" /><span class="text-xs">
+                  Unreviewed
+                </span>
               </label>
               <label class="flex items-center gap-2 px-3 py-0.5 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer whitespace-nowrap">
-                <input type="radio" name="commit-status-filter" data-status-value="reviewed" /><span class="text-xs">Reviewed</span>
+                <input type="radio" name="commit-status-filter" data-status-value="reviewed" /><span class="text-xs">
+                  Reviewed
+                </span>
               </label>
             </div>
           </div>
         </div>
 
         <div class="relative" data-repo-dropdown>
-          <button data-repo-dropdown-toggle class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light hover:border-gray-400 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400">
+          <button
+            data-repo-dropdown-toggle
+            class="flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-gray-light hover:border-gray-400 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400"
+          >
             <i class="fas fa-code-branch text-[10px]"></i>
             <span data-repo-dropdown-label>Repo</span>
             <span class="hidden w-1.5 h-1.5 rounded-full bg-blue-500 flex-none" data-repo-active></span>
             <i class="fas fa-chevron-down text-[10px] transition-transform duration-200" data-repo-dropdown-chevron></i>
           </button>
-          <div data-repo-dropdown-panel class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20 min-w-44 max-h-60 overflow-y-auto">
+          <div
+            data-repo-dropdown-panel
+            class="hidden absolute left-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-light rounded shadow-lg z-20 min-w-44 max-h-60 overflow-y-auto"
+          >
             <div data-repo-checkboxes class="py-1"></div>
           </div>
         </div>
 
         <div class="relative">
-          <i class="fas fa-search absolute left-2 top-1/2 -translate-y-1/2 text-gray-400 text-[10px] pointer-events-none"></i>
+          <i class="fas fa-search absolute left-2 top-1/2 -translate-y-1/2 text-gray-400 text-[10px] pointer-events-none">
+          </i>
           <input
             type="search"
             placeholder="Search…"
@@ -154,11 +198,18 @@
           <%= if @unreviewed_count == 0 do %>
             <i class="fas fa-trophy text-yellow-mid"></i> Nothing left to review!
           <% else %>
-            <span><i class="fas fa-eye mr-0.5"></i> <b class="text-almost-black"><%= @unreviewed_count %></b> to review</span>
+            <span>
+              <i class="fas fa-eye mr-0.5"></i> <b class="text-almost-black"><%= @unreviewed_count %></b> to review
+            </span>
             <span>·</span>
-            <span><i class="fas fa-users mr-0.5"></i> <b class="text-almost-black"><%= @others_unreviewed_count %></b> by others</span>
+            <span>
+              <i class="fas fa-users mr-0.5"></i> <b class="text-almost-black"><%= @others_unreviewed_count %></b>
+              by others
+            </span>
             <span>·</span>
-            <span><i class="fas fa-user mr-0.5"></i> <b class="text-almost-black"><%= @my_unreviewed_count %></b> by you</span>
+            <span>
+              <i class="fas fa-user mr-0.5"></i> <b class="text-almost-black"><%= @my_unreviewed_count %></b> by you
+            </span>
             <%= if @oldest_overlong_in_review_by_me do %>
               <span>·</span>
               <a
@@ -168,7 +219,9 @@
                 id="for-phx-hook-complete-your-review"
                 phx-hook="ScrollToTarget"
                 class="text-blue-600 dark:text-blue-400"
-              ><i class="far fa-snooze zzz-animation"></i> Complete your review</a>
+              >
+                <i class="far fa-snooze zzz-animation"></i> Complete your review
+              </a>
             <% end %>
             <%= if @oldest_unreviewed_for_me && !@oldest_overlong_in_review_by_me do %>
               <span>·</span>
@@ -179,7 +232,9 @@
                 id="for-phx-hook-oldest-unreviewed"
                 phx-hook="ScrollToTarget"
                 title="Go to the oldest unreviewed"
-              >↓ <%= Utils.format_datetime(@oldest_unreviewed_for_me.committed_at) %></a>
+              >
+                ↓ <%= Utils.format_datetime(@oldest_unreviewed_for_me.committed_at) %>
+              </a>
             <% end %>
           <% end %>
         <% else %>

--- a/lib/remit_web/live/commits/commits_live.html.heex
+++ b/lib/remit_web/live/commits/commits_live.html.heex
@@ -322,10 +322,16 @@
           your_last_selected_commit?={@your_last_selected_commit_id == commit.id}
           can_review?={can_review?(commit, @username, @teams_by_project)}
           compact={@features["compact_design"]}
+          copy_buttons?={@features["copy_buttons"]}
           deployed?={MapSet.member?(@deployed_shas, commit.sha)}
           comment_count={Map.get(@comment_counts, commit.sha, 0)}
           project_teams={Map.get(@teams_by_project, commit.repo, []) |> Enum.map(& &1.slug) |> Enum.join(" ")}
-          member_teams={@all_teams |> Enum.filter(fn t -> Enum.any?(commit.usernames, &(&1 in t.usernames)) end) |> Enum.map(& &1.slug) |> Enum.join(" ")}
+          member_teams={
+            @all_teams
+            |> Enum.filter(fn t -> Enum.any?(commit.usernames, &(&1 in t.usernames)) end)
+            |> Enum.map(& &1.slug)
+            |> Enum.join(" ")
+          }
         />
       <% end %>
     <% end %>

--- a/lib/remit_web/live/commits/commits_live.html.heex
+++ b/lib/remit_web/live/commits/commits_live.html.heex
@@ -255,21 +255,24 @@
     <% end %>
 
     <%= for commit <- @commits do %>
-      <RemitWeb.CommitComponent.render
-        id={commit.id}
-        commit={commit}
-        username={@username}
-        being_reviewed?={commit.review_started_at && !commit.reviewed_at}
-        reviewed?={commit.reviewed_at}
-        you_authored?={Commit.authored_by?(commit, @username)}
-        you_are_reviewing?={Commit.being_reviewed_by?(commit, @username)}
-        your_last_selected_commit?={@your_last_selected_commit_id == commit.id}
-        can_review?={can_review?(commit, @username, @teams_by_project)}
-        compact={@features["compact_design"]}
-        comment_count={Map.get(@comment_counts, commit.sha, 0)}
-        project_teams={Map.get(@teams_by_project, commit.repo, []) |> Enum.map(& &1.slug) |> Enum.join(" ")}
-        member_teams={@all_teams |> Enum.filter(fn t -> Enum.any?(commit.usernames, &(&1 in t.usernames)) end) |> Enum.map(& &1.slug) |> Enum.join(" ")}
-      />
+      <%= unless @features["build_commit_status"] && Commit.build_commit?(commit) do %>
+        <RemitWeb.CommitComponent.render
+          id={commit.id}
+          commit={commit}
+          username={@username}
+          being_reviewed?={commit.review_started_at && !commit.reviewed_at}
+          reviewed?={commit.reviewed_at}
+          you_authored?={Commit.authored_by?(commit, @username)}
+          you_are_reviewing?={Commit.being_reviewed_by?(commit, @username)}
+          your_last_selected_commit?={@your_last_selected_commit_id == commit.id}
+          can_review?={can_review?(commit, @username, @teams_by_project)}
+          compact={@features["compact_design"]}
+          deployed?={MapSet.member?(@deployed_shas, commit.sha)}
+          comment_count={Map.get(@comment_counts, commit.sha, 0)}
+          project_teams={Map.get(@teams_by_project, commit.repo, []) |> Enum.map(& &1.slug) |> Enum.join(" ")}
+          member_teams={@all_teams |> Enum.filter(fn t -> Enum.any?(commit.usernames, &(&1 in t.usernames)) end) |> Enum.map(& &1.slug) |> Enum.join(" ")}
+        />
+      <% end %>
     <% end %>
   <% end %>
 </div>

--- a/lib/remit_web/live/commits/commits_live.html.heex
+++ b/lib/remit_web/live/commits/commits_live.html.heex
@@ -46,11 +46,18 @@
         <%= if @unreviewed_count == 0 do %>
           <i class="fas fa-trophy text-yellow-mid"></i> Nothing left to review!
         <% else %>
-          <span><i class="fas fa-eye mr-0.5"></i> <b class="text-almost-black"><%= @unreviewed_count %></b> to review</span>
+          <span>
+            <i class="fas fa-eye mr-0.5"></i> <b class="text-almost-black"><%= @unreviewed_count %></b> to review
+          </span>
           <span>·</span>
-          <span><i class="fas fa-users mr-0.5"></i> <b class="text-almost-black"><%= @others_unreviewed_count %></b> by others</span>
+          <span>
+            <i class="fas fa-users mr-0.5"></i> <b class="text-almost-black"><%= @others_unreviewed_count %></b>
+            by others
+          </span>
           <span>·</span>
-          <span><i class="fas fa-user mr-0.5"></i> <b class="text-almost-black"><%= @my_unreviewed_count %></b> by you</span>
+          <span>
+            <i class="fas fa-user mr-0.5"></i> <b class="text-almost-black"><%= @my_unreviewed_count %></b> by you
+          </span>
           <%= if @oldest_overlong_in_review_by_me do %>
             <span>·</span>
             <a
@@ -60,7 +67,9 @@
               id="for-phx-hook-complete-your-review"
               phx-hook="ScrollToTarget"
               class="text-blue-600 dark:text-blue-400"
-            ><i class="far fa-snooze zzz-animation"></i> Complete your review</a>
+            >
+              <i class="far fa-snooze zzz-animation"></i> Complete your review
+            </a>
           <% end %>
           <%= if @oldest_unreviewed_for_me && !@oldest_overlong_in_review_by_me do %>
             <span>·</span>
@@ -71,7 +80,9 @@
               id="for-phx-hook-oldest-unreviewed"
               phx-hook="ScrollToTarget"
               title="Go to the oldest unreviewed"
-            >↓ <%= Utils.format_datetime(@oldest_unreviewed_for_me.committed_at) %></a>
+            >
+              ↓ <%= Utils.format_datetime(@oldest_unreviewed_for_me.committed_at) %>
+            </a>
           <% end %>
         <% end %>
       <% else %>

--- a/lib/remit_web/live/settings_live.ex
+++ b/lib/remit_web/live/settings_live.ex
@@ -238,7 +238,9 @@ defmodule RemitWeb.SettingsLive do
                 phx-value-project={@project}
                 phx-value-team={team.slug}
                 class="cursor-pointer text-gray-400 hover:text-white leading-none"
-              >×</span>
+              >
+                ×
+              </span>
             </span>
           <% end %>
         <% end %>

--- a/lib/remit_web/live/settings_live.ex
+++ b/lib/remit_web/live/settings_live.ex
@@ -105,14 +105,24 @@ defmodule RemitWeb.SettingsLive do
   defp feature_toggle(assigns) do
     ~H"""
     <label class="flex items-start gap-3 cursor-pointer select-none">
-      <input
-        type="checkbox"
-        checked={@enabled}
-        phx-click="toggle_feature"
-        phx-value-feature={@feature}
-        class="mt-0.5 cursor-pointer"
-        disabled={!assigns[:opt_in]}
-      />
+      <div class="relative block w-11 h-6 mt-0.5 shrink-0">
+        <input
+          type="checkbox"
+          checked={@enabled}
+          phx-click="toggle_feature"
+          phx-value-feature={@feature}
+          class="sr-only peer"
+        />
+        <span class="block h-6 w-11 rounded-full bg-gray-300 peer-checked:bg-blue-600 transition-colors duration-200"></span>
+        <span class="absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-gray-50 shadow transition-transform duration-200 peer-checked:translate-x-5"></span>
+      </div>
+      <div class="flex-1 min-w-0">
+        <span class="leading-none"><%= @label %></span>
+        <p class="text-xs text-gray-mid mt-0.5"><%= @description %></p>
+      </div>
+    </label>
+    """
+  end
       <div class="flex-1 min-w-0">
         <div class="flex items-center gap-2">
           <p class="text-sm text-almost-black font-medium"><%= @label %></p>

--- a/lib/remit_web/live/settings_live.ex
+++ b/lib/remit_web/live/settings_live.ex
@@ -204,10 +204,55 @@ defmodule RemitWeb.SettingsLive do
 
   defp projects(assigns) do
     ~H"""
-    <div class="bg-gray-200 px-3 py-4 mt-6">
+    <div class={["bg-gray-200 px-3 py-4 mt-6", @compact && "rounded-2xl shadow-sm"]}>
       <h2 class="font-semibold text-xs mb-2 uppercase">Project ownership</h2>
-      <%= for {project, project_teams} <- @projects do %>
-        <.project project={project} project_teams={project_teams} teams={@teams} new_design?={false} />
+      <%= if @compact do %>
+        <div class="divide-y divide-gray-300 dark:divide-gray-600">
+          <%= for {project, project_teams} <- @projects do %>
+            <.project_row project={project} project_teams={project_teams} all_teams={@teams} />
+          <% end %>
+        </div>
+      <% else %>
+        <%= for {project, project_teams} <- @projects do %>
+          <.project project={project} project_teams={project_teams} teams={@teams} />
+        <% end %>
+      <% end %>
+    </div>
+    """
+  end
+
+  defp project_row(assigns) do
+    ~H"""
+    <% available_teams = @all_teams -- @project_teams %>
+    <div class="flex items-center gap-3 py-2 min-h-[2rem]">
+      <span class="font-semibold text-xs w-32 shrink-0"><%= @project %></span>
+      <div class="flex flex-wrap gap-1 flex-1 min-w-0">
+        <%= if @project_teams == [] do %>
+          <span class="text-red-600 text-xs italic">unclaimed</span>
+        <% else %>
+          <%= for team <- @project_teams do %>
+            <span class="inline-flex items-center gap-1 pl-2 pr-1.5 py-0.5 text-xs bg-gray-700 dark:bg-gray-600 text-white rounded-full select-none">
+              <%= team.name %>
+              <span
+                phx-click="remove_project_owner"
+                phx-value-project={@project}
+                phx-value-team={team.slug}
+                class="cursor-pointer text-gray-400 hover:text-white leading-none"
+              >×</span>
+            </span>
+          <% end %>
+        <% end %>
+      </div>
+      <%= if available_teams != [] do %>
+        <.form for={%{}} as={:project} phx-submit="add_project_owner" class="flex items-center gap-1 shrink-0">
+          <input type="hidden" name="project" value={@project} />
+          <select name="team" class="text-xs h-5 py-0">
+            <%= for team <- available_teams do %>
+              <option value={team.slug}><%= team.name %></option>
+            <% end %>
+          </select>
+          <%= submit("Add", class: "text-xs h-5 px-2 py-0") %>
+        </.form>
       <% end %>
     </div>
     """

--- a/lib/remit_web/live/settings_live.ex
+++ b/lib/remit_web/live/settings_live.ex
@@ -101,12 +101,12 @@ defmodule RemitWeb.SettingsLive do
         phx-click="toggle_feature"
         phx-value-feature={@feature}
         class="mt-0.5 cursor-pointer"
-        disabled
+        disabled={!assigns[:opt_in]}
       />
       <div class="flex-1 min-w-0">
         <div class="flex items-center gap-2">
           <p class="text-sm text-almost-black font-medium"><%= @label %></p>
-          <%= if @todo do %>
+          <%= if assigns[:todo] do %>
             <span class="text-xs text-yellow-600 bg-yellow-100 px-1.5 py-0.5 rounded" title="Work in progress">🚧 WIP</span>
           <% end %>
         </div>

--- a/lib/remit_web/live/settings_live.ex
+++ b/lib/remit_web/live/settings_live.ex
@@ -45,6 +45,16 @@ defmodule RemitWeb.SettingsLive do
     |> noreply()
   end
 
+  def handle_event("set_feature", %{"feature" => feature, "enabled" => enabled}, socket) do
+    new_flags = Map.put(socket.assigns.features, feature, enabled == "true")
+    Settings.broadcast(session_id(socket), :feature_flags, new_flags)
+
+    socket
+    |> assign(features: new_flags)
+    |> push_event("feature-flags-updated", new_flags)
+    |> noreply()
+  end
+
   def handle_event(
         "update_reviewed_commit_cutoff",
         %{"reviewed_commit_cutoff" => %{"days" => days, "commits" => commits}},
@@ -113,6 +123,37 @@ defmodule RemitWeb.SettingsLive do
         <p class="text-xs text-gray-mid"><%= @description %></p>
       </div>
     </label>
+    """
+  end
+
+  defp theme_toggle(assigns) do
+    ~H"""
+    <div class="relative block w-11 h-6 cursor-pointer select-none">
+      <input
+        type="checkbox"
+        checked={@dark?}
+        phx-click="toggle_feature"
+        phx-value-feature="dark_theme"
+        class="sr-only peer"
+      />
+      <%!-- Track --%>
+      <span class="block h-6 w-11 rounded-full bg-gray-300 dark:bg-gray-600 peer-checked:bg-blue-600 transition-colors duration-200">
+      </span>
+      <%!-- Thumb --%>
+      <span class="absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-gray-50 shadow transition-transform duration-200 peer-checked:translate-x-5">
+      </span>
+      <%!-- Moon icon (visible when dark theme on) --%>
+      <span class="absolute left-1.5 top-1.5 hidden peer-checked:block text-white" style="font-size: 10px; line-height: 1;">
+        <i class="fas fa-moon"></i>
+      </span>
+      <%!-- Sun icon (visible when dark theme off) --%>
+      <span
+        class="absolute right-1.5 top-1.5 block peer-checked:hidden text-amber-500"
+        style="font-size: 10px; line-height: 1;"
+      >
+        <i class="fas fa-sun"></i>
+      </span>
+    </div>
     """
   end
 

--- a/lib/remit_web/live/settings_live.ex
+++ b/lib/remit_web/live/settings_live.ex
@@ -21,6 +21,7 @@ defmodule RemitWeb.SettingsLive do
     |> assign_teams()
     |> assign(reviewed_commit_cutoff: get_reviewed_commit_cutoff(session, %{"days" => 7, "commits" => 100}))
     |> assign(features: features)
+    |> assign(build_commit_repos: get_build_commit_repos(session))
     |> ok()
   end
 
@@ -33,6 +34,17 @@ defmodule RemitWeb.SettingsLive do
   def handle_event("remove_project_owner", %{"project" => project, "team" => team}, socket) do
     Remit.Team.remove_project(team, project)
     noreply(socket)
+  end
+
+  def handle_event("toggle_build_commit_repo", %{"repo" => repo}, socket) do
+    repos = socket.assigns.build_commit_repos
+    new_repos = if repo in repos, do: repos -- [repo], else: [repo | repos]
+    Settings.broadcast(session_id(socket), :build_commit_repos, new_repos)
+
+    socket
+    |> assign(build_commit_repos: new_repos)
+    |> push_event("build-commit-repos-updated", %{repos: new_repos})
+    |> noreply()
   end
 
   def handle_event("toggle_feature", %{"feature" => feature}, socket) do

--- a/lib/remit_web/live/settings_live.ex
+++ b/lib/remit_web/live/settings_live.ex
@@ -102,7 +102,7 @@ defmodule RemitWeb.SettingsLive do
     {:noreply, socket}
   end
 
-  defp feature_toggle(assigns) do
+  defp toggle_preference(assigns) do
     ~H"""
     <label class="flex items-start gap-3 cursor-pointer select-none">
       <div class="relative block w-11 h-6 mt-0.5 shrink-0">
@@ -113,24 +113,47 @@ defmodule RemitWeb.SettingsLive do
           phx-value-feature={@feature}
           class="sr-only peer"
         />
-        <span class="block h-6 w-11 rounded-full bg-gray-300 peer-checked:bg-blue-600 transition-colors duration-200"></span>
-        <span class="absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-gray-50 shadow transition-transform duration-200 peer-checked:translate-x-5"></span>
+        <span class="block h-6 w-11 rounded-full bg-gray-300 peer-checked:bg-blue-600 transition-colors duration-200">
+        </span>
+        <span class="absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-gray-50 shadow transition-transform duration-200 peer-checked:translate-x-5">
+        </span>
       </div>
       <div class="flex-1 min-w-0">
-        <span class="leading-none"><%= @label %></span>
+        <span class="leading-none font-bold"><%= @label %></span>
         <p class="text-xs text-gray-mid mt-0.5"><%= @description %></p>
       </div>
     </label>
     """
   end
+
+  defp feature_toggle(assigns) do
+    ~H"""
+    <label class={[
+      "flex items-start gap-3 select-none",
+      if(assigns[:opt_in], do: "cursor-pointer", else: "cursor-not-allowed opacity-50")
+    ]}>
+      <div class="relative block w-11 h-6 mt-0.5 shrink-0">
+        <input
+          type="checkbox"
+          checked={@enabled}
+          phx-click="toggle_feature"
+          phx-value-feature={@feature}
+          class="sr-only peer"
+          disabled={!assigns[:opt_in]}
+        />
+        <span class="block h-6 w-11 rounded-full bg-gray-300 peer-checked:bg-blue-600 transition-colors duration-200">
+        </span>
+        <span class="absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-gray-50 shadow transition-transform duration-200 peer-checked:translate-x-5">
+        </span>
+      </div>
       <div class="flex-1 min-w-0">
         <div class="flex items-center gap-2">
-          <p class="text-sm text-almost-black font-medium"><%= @label %></p>
+          <span class="leading-none font-bold"><%= @label %></span>
           <%= if assigns[:todo] do %>
             <span class="text-xs text-yellow-600 bg-yellow-100 px-1.5 py-0.5 rounded" title="Work in progress">🚧 WIP</span>
           <% end %>
         </div>
-        <p class="text-xs text-gray-mid"><%= @description %></p>
+        <p class="text-xs text-gray-mid mt-0.5"><%= @description %></p>
       </div>
     </label>
     """

--- a/lib/remit_web/live/settings_live.ex
+++ b/lib/remit_web/live/settings_live.ex
@@ -204,7 +204,7 @@ defmodule RemitWeb.SettingsLive do
 
   defp projects(assigns) do
     ~H"""
-    <div class={["bg-gray-200 px-3 py-4 mt-6", @compact && "rounded-2xl shadow-sm"]}>
+    <div class={["bg-gray-100 dark:bg-gray-800 px-3 py-4 mt-6", @compact && "rounded-xl shadow-sm"]}>
       <h2 class="font-semibold text-xs mb-2 uppercase">Project ownership</h2>
       <%= if @compact do %>
         <div class="divide-y divide-gray-300 dark:divide-gray-600">

--- a/lib/remit_web/live/settings_live.html.heex
+++ b/lib/remit_web/live/settings_live.html.heex
@@ -25,21 +25,6 @@
     <% end %>
   </div>
 
-  <%!-- Display settings --%>
-  <div>
-    <.form
-      :let={f}
-      for={%{}}
-      as={:reviewed_commit_cutoff}
-      id="reviewed_commit_cutoff_form"
-      phx-change="update_reviewed_commit_cutoff"
-      phx-hook="SetReviewedCommitCutoff"
-    >
-      Hide reviewed commits
-      after <%= text_input(f, :days, value: @reviewed_commit_cutoff["days"], size: 2) %> days
-      or <%= text_input(f, :commits, value: @reviewed_commit_cutoff["commits"], size: 3) %> commits (0 to disable).
-    </.form>
-  </div>
 
   <%!-- GitHub teams --%>
   <%= if @username && Remit.Config.has_github_org? do %>
@@ -81,6 +66,30 @@
       If you see <RemitWeb.NoUsernameComponent.render tooltip?={false} />
       on a commit, Remit can't notify the author about comments on it – fix it for future commits by following the instructions above.
     </p>
+  </div>
+
+  <%!-- Preferences --%>
+  <div id="theme-preferences" phx-hook="FeatureToggle" class="bg-gray-200 px-3 py-4 mt-6 text-almost-black">
+    <h2 class="font-semibold text-xs mb-3 uppercase">Preferences</h2>
+
+    <div class="space-y-3">
+      <.form
+        :let={f}
+        for={%{}}
+        as={:reviewed_commit_cutoff}
+        id="reviewed_commit_cutoff_form"
+        phx-change="update_reviewed_commit_cutoff"
+        phx-hook="SetReviewedCommitCutoff"
+        class="flex items-center gap-2 flex-wrap"
+      >
+        <span class="leading-none">Hide reviewed commits after</span>
+        <%= text_input(f, :days, value: @reviewed_commit_cutoff["days"], class: "w-10 text-center rounded-sm") %>
+        <span class="leading-none">days or</span>
+        <%= text_input(f, :commits, value: @reviewed_commit_cutoff["commits"], class: "w-14 text-center rounded-sm") %>
+        <span class="leading-none">commits</span>
+        <span class="leading-none text-gray-mid">(0 to disable)</span>
+      </.form>
+    </div>
   </div>
 
   <%!-- Project ownership --%>

--- a/lib/remit_web/live/settings_live.html.heex
+++ b/lib/remit_web/live/settings_live.html.heex
@@ -115,6 +115,13 @@
         label="Unresolved comments count"
         description="Show the number of unresolved in the comments tab header."
       />
+
+      <.toggle_preference
+        feature="comment_count_badge"
+        enabled={@features["comment_count_badge"]}
+        label="Comment count per commit"
+        description="Show a badge with the number of comments on each commit."
+      />
     </div>
   </div>
 

--- a/lib/remit_web/live/settings_live.html.heex
+++ b/lib/remit_web/live/settings_live.html.heex
@@ -25,7 +25,6 @@
     <% end %>
   </div>
 
-
   <%!-- GitHub teams --%>
   <%= if @username && Remit.Config.has_github_org? do %>
     <div class="bg-gray-200 px-3 py-4 mt-6 paragraphs">

--- a/lib/remit_web/live/settings_live.html.heex
+++ b/lib/remit_web/live/settings_live.html.heex
@@ -135,6 +135,13 @@
         label="Comment count per commit"
         description="Show a badge with the number of comments on each commit."
       />
+
+      <.toggle_preference
+        feature="copy_buttons"
+        enabled={@features["copy_buttons"]}
+        label="Copy SHA / link buttons"
+        description="Show copy-to-clipboard buttons on hover for each commit's short SHA and URL."
+      />
     </div>
   </div>
 

--- a/lib/remit_web/live/settings_live.html.heex
+++ b/lib/remit_web/live/settings_live.html.heex
@@ -153,9 +153,8 @@
         feature="build_commit_status"
         enabled={@features["build_commit_status"]}
         label="Use build commits as commit status"
-        description="Show build commit results as the commit status indicator."
-        todo={true}
-        opt_in={false}
+        description="Collapse deploy commits and show a 'deployed' badge on reviewed commits."
+        opt_in={true}
       />
     </div>
   </div>

--- a/lib/remit_web/live/settings_live.html.heex
+++ b/lib/remit_web/live/settings_live.html.heex
@@ -153,6 +153,8 @@
     <h2 class="font-semibold text-xs mb-2 uppercase">
       <i class="fas fa-flask text-purple-400 mr-1"></i> Experimental features
     </h2>
+    <p>For things a bit more controversial that still need a bit of testing.</p>
+
     <div id="feature-toggles" phx-hook="FeatureToggle" class="mt-2 space-y-2">
       <.feature_toggle
         feature="compact_design"

--- a/lib/remit_web/live/settings_live.html.heex
+++ b/lib/remit_web/live/settings_live.html.heex
@@ -1,4 +1,5 @@
 <div class="mx-6">
+  <%!-- Profile --%>
   <div class="flex items-center">
     <div class="flex-1 min-w-0 my-6">
       <%= if @username do %>
@@ -24,6 +25,7 @@
     <% end %>
   </div>
 
+  <%!-- Display settings --%>
   <div>
     <.form
       :let={f}
@@ -39,6 +41,7 @@
     </.form>
   </div>
 
+  <%!-- GitHub teams --%>
   <%= if @username && Remit.Config.has_github_org? do %>
     <div class="bg-gray-200 px-3 py-4 mt-6 paragraphs">
       <%= link("Import team members from GitHub",
@@ -62,6 +65,7 @@
     </div>
   <% end %>
 
+  <%!-- Commit authors --%>
   <div class="bg-gray-200 px-3 py-4 mt-6 text-almost-black paragraphs">
     <h2 class="font-semibold text-xs mb-2 uppercase">
       <i class="fas fa-info-circle fa-2x text-blue-400 align-middle mr-1"></i> A little guide to commit authors
@@ -79,7 +83,8 @@
     </p>
   </div>
 
-  <.projects projects={@projects} teams={@teams} />
+  <%!-- Project ownership --%>
+  <.projects projects={@projects} teams={@teams} new_design?={false} />
 
   <%!-- Experimental features --%>
   <div class="bg-gray-200 px-3 py-4 mt-6">
@@ -93,6 +98,7 @@
         label="Compact design"
         description="Lighter background and refreshed UI. Takes effect after reload."
         todo={true}
+        opt_in={true}
       />
       <.feature_toggle
         feature="advanced_filters"
@@ -100,6 +106,7 @@
         label="Advanced filters"
         description="Accordion filter bar with author, project, member and search filters."
         todo={true}
+        opt_in={false}
       />
       <.feature_toggle
         feature="build_commit_status"
@@ -107,6 +114,7 @@
         label="Use build commits as commit status"
         description="Show build commit results as the commit status indicator."
         todo={true}
+        opt_in={false}
       />
     </div>
   </div>

--- a/lib/remit_web/live/settings_live.html.heex
+++ b/lib/remit_web/live/settings_live.html.heex
@@ -54,7 +54,10 @@
   <% end %>
 
   <%!-- Commit authors --%>
-  <div class={["bg-gray-200 px-3 py-4 mt-6 text-almost-black paragraphs", @features["compact_design"] && "rounded-2xl shadow-sm"]}>
+  <div class={[
+    "bg-gray-200 px-3 py-4 mt-6 text-almost-black paragraphs",
+    @features["compact_design"] && "rounded-2xl shadow-sm"
+  ]}>
     <h2 class="font-semibold text-xs mb-2 uppercase">
       <i class="fas fa-info-circle fa-2x text-blue-400 align-middle mr-1"></i> A little guide to commit authors
     </h2>
@@ -72,7 +75,11 @@
   </div>
 
   <%!-- Preferences --%>
-  <div id="theme-preferences" phx-hook="FeatureToggle" class={["bg-gray-200 px-3 py-4 mt-6 text-almost-black", @features["compact_design"] && "rounded-2xl shadow-sm"]}>
+  <div
+    id="theme-preferences"
+    phx-hook="FeatureToggle"
+    class={["bg-gray-200 px-3 py-4 mt-6 text-almost-black", @features["compact_design"] && "rounded-2xl shadow-sm"]}
+  >
     <h2 class="font-semibold text-xs mb-3 uppercase">Preferences</h2>
 
     <div class="space-y-3">

--- a/lib/remit_web/live/settings_live.html.heex
+++ b/lib/remit_web/live/settings_live.html.heex
@@ -89,6 +89,11 @@
         <span class="leading-none">commits</span>
         <span class="leading-none text-gray-mid">(0 to disable)</span>
       </.form>
+
+      <label class="flex items-center gap-3 cursor-pointer select-none">
+        <.theme_toggle dark?={@features["dark_theme"]} />
+        <span class="leading-none font-bold">Theme</span>
+      </label>
     </div>
   </div>
 

--- a/lib/remit_web/live/settings_live.html.heex
+++ b/lib/remit_web/live/settings_live.html.heex
@@ -172,8 +172,8 @@
       <.feature_toggle
         feature="build_commit_status"
         enabled={@features["build_commit_status"]}
-        label="Use build commits as commit status"
-        description="Collapse deploy commits and show a 'deployed' badge on reviewed commits."
+        label="Hide build commits from infra-as-code repos"
+        description="If a deploy repo is selected, its commits will be hidden. A 'deployed' badge will appear on the matching commits."
         opt_in={true}
       />
       <%= if @features["build_commit_status"] do %>

--- a/lib/remit_web/live/settings_live.html.heex
+++ b/lib/remit_web/live/settings_live.html.heex
@@ -94,6 +94,13 @@
         <.theme_toggle dark?={@features["dark_theme"]} />
         <span class="leading-none font-bold">Theme</span>
       </label>
+
+      <.toggle_preference
+        feature="inbox_count_badge"
+        enabled={@features["inbox_count_badge"]}
+        label="Unresolved comments count"
+        description="Show the number of unresolved in the comments tab header."
+      />
     </div>
   </div>
 

--- a/lib/remit_web/live/settings_live.html.heex
+++ b/lib/remit_web/live/settings_live.html.heex
@@ -2,7 +2,7 @@
   <%!-- Profile --%>
   <div class={[
     "flex items-center",
-    if(@features["compact_design"], do: "-mx-6 px-6 bg-gray-200 py-2 mb-2", else: "")
+    if(@features["compact_design"], do: "px-3 bg-gray-100 dark:bg-gray-800 py-2 mb-2 min-h-12 rounded-xl shadow-sm", else: "")
   ]}>
     <div class={["flex-1 min-w-0", if(@features["compact_design"], do: "", else: "my-6")]}>
       <%= if @username do %>
@@ -26,12 +26,16 @@
         tooltip: "Behold! Your GitHub avatar!",
         tooltip_pos: "left"
       ) %>
+    <% else %>
+      <%= if @features["compact_design"] do %>
+        <div class="ml-3 w-10 h-10 bg-gray-300 dark:bg-gray-600 flex-none" style="clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)"></div>
+      <% end %>
     <% end %>
   </div>
 
   <%!-- GitHub teams --%>
   <%= if @username && Remit.Config.has_github_org? do %>
-    <div class={["bg-gray-200 px-3 py-4 mt-6 paragraphs", @features["compact_design"] && "rounded-2xl shadow-sm"]}>
+    <div class={["bg-gray-100 dark:bg-gray-800 px-3 py-4 mt-6 paragraphs", @features["compact_design"] && "rounded-xl shadow-sm"]}>
       <%= link("Import team members from GitHub",
         to: ~p"/settings",
         id: "update-github-teams",
@@ -55,11 +59,11 @@
 
   <%!-- Commit authors --%>
   <div class={[
-    "bg-gray-200 px-3 py-4 mt-6 text-almost-black paragraphs",
-    @features["compact_design"] && "rounded-2xl shadow-sm"
+    "bg-gray-100 dark:bg-gray-800 px-3 py-4 mt-6 text-almost-black paragraphs",
+    @features["compact_design"] && "rounded-xl shadow-sm"
   ]}>
     <h2 class="font-semibold text-xs mb-2 uppercase">
-      <i class="fas fa-info-circle fa-2x text-blue-400 align-middle mr-1"></i> A little guide to commit authors
+      <i class="fas fa-info-circle fa-2x text-blue-600 align-middle mr-1"></i> A little guide to commit authors
     </h2>
 
     <p>
@@ -78,7 +82,7 @@
   <div
     id="theme-preferences"
     phx-hook="FeatureToggle"
-    class={["bg-gray-200 px-3 py-4 mt-6 text-almost-black", @features["compact_design"] && "rounded-2xl shadow-sm"]}
+    class={["bg-gray-100 dark:bg-gray-800 px-3 py-4 mt-6 text-almost-black", @features["compact_design"] && "rounded-xl shadow-sm"]}
   >
     <h2 class="font-semibold text-xs mb-3 uppercase">Preferences</h2>
 
@@ -118,7 +122,7 @@
   <.projects projects={@projects} teams={@teams} compact={@features["compact_design"]} />
 
   <%!-- Experimental features --%>
-  <div class={["bg-gray-200 px-3 py-4 mt-6", @features["compact_design"] && "rounded-2xl shadow-sm"]}>
+  <div class={["bg-gray-100 dark:bg-gray-800 px-3 py-4 mt-6", @features["compact_design"] && "rounded-xl shadow-sm"]}>
     <h2 class="font-semibold text-xs mb-2 uppercase">
       <i class="fas fa-flask text-purple-400 mr-1"></i> Experimental features
     </h2>

--- a/lib/remit_web/live/settings_live.html.heex
+++ b/lib/remit_web/live/settings_live.html.heex
@@ -2,7 +2,10 @@
   <%!-- Profile --%>
   <div class={[
     "flex items-center",
-    if(@features["compact_design"], do: "px-3 bg-gray-100 dark:bg-gray-800 py-2 mb-2 min-h-12 rounded-xl shadow-sm", else: "")
+    if(@features["compact_design"],
+      do: "px-3 bg-gray-100 dark:bg-gray-800 py-2 mb-2 min-h-12 rounded-xl shadow-sm",
+      else: ""
+    )
   ]}>
     <div class={["flex-1 min-w-0", if(@features["compact_design"], do: "", else: "my-6")]}>
       <%= if @username do %>
@@ -28,14 +31,21 @@
       ) %>
     <% else %>
       <%= if @features["compact_design"] do %>
-        <div class="ml-3 w-10 h-10 bg-gray-300 dark:bg-gray-600 flex-none" style="clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)"></div>
+        <div
+          class="ml-3 w-10 h-10 bg-gray-300 dark:bg-gray-600 flex-none"
+          style="clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)"
+        >
+        </div>
       <% end %>
     <% end %>
   </div>
 
   <%!-- GitHub teams --%>
   <%= if @username && Remit.Config.has_github_org? do %>
-    <div class={["bg-gray-100 dark:bg-gray-800 px-3 py-4 mt-6 paragraphs", @features["compact_design"] && "rounded-xl shadow-sm"]}>
+    <div class={[
+      "bg-gray-100 dark:bg-gray-800 px-3 py-4 mt-6 paragraphs",
+      @features["compact_design"] && "rounded-xl shadow-sm"
+    ]}>
       <%= link("Import team members from GitHub",
         to: ~p"/settings",
         id: "update-github-teams",
@@ -82,7 +92,10 @@
   <div
     id="theme-preferences"
     phx-hook="FeatureToggle"
-    class={["bg-gray-100 dark:bg-gray-800 px-3 py-4 mt-6 text-almost-black", @features["compact_design"] && "rounded-xl shadow-sm"]}
+    class={[
+      "bg-gray-100 dark:bg-gray-800 px-3 py-4 mt-6 text-almost-black",
+      @features["compact_design"] && "rounded-xl shadow-sm"
+    ]}
   >
     <h2 class="font-semibold text-xs mb-3 uppercase">Preferences</h2>
 
@@ -166,7 +179,9 @@
                 phx-click="toggle_build_commit_repo"
                 phx-value-repo={repo}
                 class="cursor-pointer text-gray-400 hover:text-white leading-none"
-              >×</span>
+              >
+                ×
+              </span>
             </span>
           <% end %>
           <%= if available_repos != [] do %>

--- a/lib/remit_web/live/settings_live.html.heex
+++ b/lib/remit_web/live/settings_live.html.heex
@@ -156,6 +156,31 @@
         description="Collapse deploy commits and show a 'deployed' badge on reviewed commits."
         opt_in={true}
       />
+      <%= if @features["build_commit_status"] do %>
+        <% available_repos = Enum.map(@projects, &elem(&1, 0)) -- @build_commit_repos %>
+        <div id="build-commit-repos" phx-hook="BuildCommitRepos" class="ml-14 flex flex-wrap items-center gap-1">
+          <%= for repo <- @build_commit_repos do %>
+            <span class="inline-flex items-center gap-1 pl-2 pr-1.5 py-0.5 text-xs bg-gray-700 dark:bg-gray-600 text-white rounded-full select-none">
+              <%= repo %>
+              <span
+                phx-click="toggle_build_commit_repo"
+                phx-value-repo={repo}
+                class="cursor-pointer text-gray-400 hover:text-white leading-none"
+              >×</span>
+            </span>
+          <% end %>
+          <%= if available_repos != [] do %>
+            <.form for={%{}} phx-submit="toggle_build_commit_repo" class="flex items-center gap-1 shrink-0">
+              <select name="repo" class="text-xs h-5 py-0">
+                <%= for repo <- available_repos do %>
+                  <option value={repo}><%= repo %></option>
+                <% end %>
+              </select>
+              <%= submit("Add", class: "text-xs h-5 px-2 py-0") %>
+            </.form>
+          <% end %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/lib/remit_web/live/settings_live.html.heex
+++ b/lib/remit_web/live/settings_live.html.heex
@@ -135,9 +135,8 @@
         feature="advanced_filters"
         enabled={@features["advanced_filters"]}
         label="Advanced filters"
-        description="Accordion filter bar with author, project, member and search filters."
-        todo={true}
-        opt_in={false}
+        description="Accordion filter bar with search and repo filter for commits."
+        opt_in={true}
       />
       <.feature_toggle
         feature="build_commit_status"

--- a/lib/remit_web/live/settings_live.html.heex
+++ b/lib/remit_web/live/settings_live.html.heex
@@ -1,7 +1,10 @@
 <div class="mx-6">
   <%!-- Profile --%>
-  <div class="flex items-center">
-    <div class="flex-1 min-w-0 my-6">
+  <div class={[
+    "flex items-center",
+    if(@features["compact_design"], do: "-mx-6 px-6 bg-gray-200 py-2 mb-2", else: "")
+  ]}>
+    <div class={["flex-1 min-w-0", if(@features["compact_design"], do: "", else: "my-6")]}>
       <%= if @username do %>
         Logged in as: <span class="font-bold"><%= @username %></span>
         · <%= link("Log out",
@@ -16,9 +19,10 @@
     </div>
 
     <%= if @username do %>
-      <%= github_avatar(@username, 80,
+      <%= github_avatar(@username, if(@features["compact_design"], do: 40, else: 80),
         alt: "",
         class: "ml-3",
+        shape: if(@features["compact_design"], do: :hexagon, else: :default),
         tooltip: "Behold! Your GitHub avatar!",
         tooltip_pos: "left"
       ) %>
@@ -27,7 +31,7 @@
 
   <%!-- GitHub teams --%>
   <%= if @username && Remit.Config.has_github_org? do %>
-    <div class="bg-gray-200 px-3 py-4 mt-6 paragraphs">
+    <div class={["bg-gray-200 px-3 py-4 mt-6 paragraphs", @features["compact_design"] && "rounded-2xl shadow-sm"]}>
       <%= link("Import team members from GitHub",
         to: ~p"/settings",
         id: "update-github-teams",
@@ -50,7 +54,7 @@
   <% end %>
 
   <%!-- Commit authors --%>
-  <div class="bg-gray-200 px-3 py-4 mt-6 text-almost-black paragraphs">
+  <div class={["bg-gray-200 px-3 py-4 mt-6 text-almost-black paragraphs", @features["compact_design"] && "rounded-2xl shadow-sm"]}>
     <h2 class="font-semibold text-xs mb-2 uppercase">
       <i class="fas fa-info-circle fa-2x text-blue-400 align-middle mr-1"></i> A little guide to commit authors
     </h2>
@@ -68,7 +72,7 @@
   </div>
 
   <%!-- Preferences --%>
-  <div id="theme-preferences" phx-hook="FeatureToggle" class="bg-gray-200 px-3 py-4 mt-6 text-almost-black">
+  <div id="theme-preferences" phx-hook="FeatureToggle" class={["bg-gray-200 px-3 py-4 mt-6 text-almost-black", @features["compact_design"] && "rounded-2xl shadow-sm"]}>
     <h2 class="font-semibold text-xs mb-3 uppercase">Preferences</h2>
 
     <div class="space-y-3">
@@ -104,10 +108,10 @@
   </div>
 
   <%!-- Project ownership --%>
-  <.projects projects={@projects} teams={@teams} new_design?={false} />
+  <.projects projects={@projects} teams={@teams} compact={@features["compact_design"]} />
 
   <%!-- Experimental features --%>
-  <div class="bg-gray-200 px-3 py-4 mt-6">
+  <div class={["bg-gray-200 px-3 py-4 mt-6", @features["compact_design"] && "rounded-2xl shadow-sm"]}>
     <h2 class="font-semibold text-xs mb-2 uppercase">
       <i class="fas fa-flask text-purple-400 mr-1"></i> Experimental features
     </h2>

--- a/lib/remit_web/live/tabs_live.ex
+++ b/lib/remit_web/live/tabs_live.ex
@@ -82,6 +82,8 @@ defmodule RemitWeb.TabsLive do
     socket |> assign_username(login) |> assign_tab_notification() |> noreply()
   end
 
+  def handle_info(_message, socket), do: noreply(socket)
+
   @impl Phoenix.LiveView
   def handle_params(_params, _uri, socket) do
     # Since the child LiveViews run concurrently, they can't be relied on to set the title themselves.

--- a/lib/remit_web/live/tabs_live.ex
+++ b/lib/remit_web/live/tabs_live.ex
@@ -2,7 +2,7 @@
 # Read more: https://elixirforum.com/t/tabbed-interface-with-multiple-liveviews/31670
 defmodule RemitWeb.TabsLive do
   use RemitWeb, :live_view
-  alias Remit.{Comments, GithubAuth}
+  alias Remit.{Comments, GithubAuth, Settings}
 
   defp default_tabs do
     [
@@ -20,7 +20,8 @@ defmodule RemitWeb.TabsLive do
         module: RemitWeb.CommentsLive,
         text: "Comments",
         icon: "fa-comments",
-        has_notification: false
+        has_notification: false,
+        notification_count: nil
       },
       %{
         action: :settings,
@@ -52,11 +53,13 @@ defmodule RemitWeb.TabsLive do
     if connected?(socket) do
       Comments.subscribe()
       GithubAuth.subscribe(session["session_id"])
+      Settings.subscribe(session["session_id"])
     end
 
     socket
     |> assign_username(github_login(session))
     |> assign_default_params(session)
+    |> assign(inbox_count_badge: get_feature_flags(session)["inbox_count_badge"])
     |> assign_tab_notification()
     |> ok()
   end
@@ -64,6 +67,13 @@ defmodule RemitWeb.TabsLive do
   @impl Phoenix.LiveView
   def handle_info(:comments_changed, socket) do
     socket |> assign_tab_notification() |> noreply()
+  end
+
+  def handle_info({:setting_updated, :feature_flags, flags}, socket) do
+    socket
+    |> assign(inbox_count_badge: flags["inbox_count_badge"])
+    |> assign_tab_notification()
+    |> noreply()
   end
 
   def handle_info({:login, %Remit.Github.User{login: login}}, socket) do
@@ -110,16 +120,29 @@ defmodule RemitWeb.TabsLive do
   end
 
   defp update_tab_state(socket, %{:action => :comments} = tab) do
-    has_notification =
-      Comments.list_notifications(
-        limit: 1,
-        username: socket.assigns.username,
-        resolved_filter: socket.assigns.is,
-        user_filter: socket.assigns.role
-      )
-      |> Enum.any?()
+    if socket.assigns.inbox_count_badge do
+      count =
+        Comments.list_notifications(
+          limit: 99,
+          username: socket.assigns.username,
+          resolved_filter: "unresolved",
+          user_filter: socket.assigns.role
+        )
+        |> length()
 
-    %{tab | has_notification: has_notification}
+      %{tab | has_notification: count > 0, notification_count: count}
+    else
+      has_notification =
+        Comments.list_notifications(
+          limit: 1,
+          username: socket.assigns.username,
+          resolved_filter: socket.assigns.is,
+          user_filter: socket.assigns.role
+        )
+        |> Enum.any?()
+
+      %{tab | has_notification: has_notification, notification_count: nil}
+    end
   end
 
   defp update_tab_state(_socket, tab), do: tab

--- a/lib/remit_web/live/tabs_live.ex
+++ b/lib/remit_web/live/tabs_live.ex
@@ -60,6 +60,7 @@ defmodule RemitWeb.TabsLive do
     |> assign_username(github_login(session))
     |> assign_default_params(session)
     |> assign(inbox_count_badge: get_feature_flags(session)["inbox_count_badge"])
+    |> assign(compact_design: get_feature_flags(session)["compact_design"])
     |> assign_tab_notification()
     |> ok()
   end
@@ -72,6 +73,7 @@ defmodule RemitWeb.TabsLive do
   def handle_info({:setting_updated, :feature_flags, flags}, socket) do
     socket
     |> assign(inbox_count_badge: flags["inbox_count_badge"])
+    |> assign(compact_design: flags["compact_design"])
     |> assign_tab_notification()
     |> noreply()
   end

--- a/lib/remit_web/live_view_helpers.ex
+++ b/lib/remit_web/live_view_helpers.ex
@@ -84,7 +84,12 @@ defmodule RemitWeb.LiveViewHelpers do
     Map.merge(default, Map.get(session, "reviewed_commit_cutoff", %{}))
   end
 
-  @feature_defaults %{"compact_design" => false, "advanced_filters" => false, "build_status_commits" => false}
+  @feature_defaults %{
+    "compact_design" => false,
+    "advanced_filters" => false,
+    "build_commit_status" => false,
+    "dark_theme" => false
+  }
 
   def get_feature_flags(session) do
     Map.merge(@feature_defaults, Map.get(session, "feature_flags", %{}))

--- a/lib/remit_web/live_view_helpers.ex
+++ b/lib/remit_web/live_view_helpers.ex
@@ -88,7 +88,8 @@ defmodule RemitWeb.LiveViewHelpers do
     "compact_design" => false,
     "advanced_filters" => false,
     "build_commit_status" => false,
-    "dark_theme" => false
+    "dark_theme" => false,
+    "inbox_count_badge" => false
   }
 
   def get_feature_flags(session) do

--- a/lib/remit_web/live_view_helpers.ex
+++ b/lib/remit_web/live_view_helpers.ex
@@ -36,6 +36,7 @@ defmodule RemitWeb.LiveViewHelpers do
         :hexagon ->
           hex_clip = "polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)"
           {[style: "clip-path: #{hex_clip}; overflow: hidden; width: #{size}px; height: #{size}px;"], "bg-gray-mid"}
+
         _ ->
           {[], "rounded-sm bg-gray-mid"}
       end

--- a/lib/remit_web/live_view_helpers.ex
+++ b/lib/remit_web/live_view_helpers.ex
@@ -84,7 +84,7 @@ defmodule RemitWeb.LiveViewHelpers do
     Map.merge(default, Map.get(session, "reviewed_commit_cutoff", %{}))
   end
 
-  @feature_defaults %{"new_design" => false, "advanced_filters" => false, "build_status_commits" => false}
+  @feature_defaults %{"compact_design" => false, "advanced_filters" => false, "build_status_commits" => false}
 
   def get_feature_flags(session) do
     Map.merge(@feature_defaults, Map.get(session, "feature_flags", %{}))

--- a/lib/remit_web/live_view_helpers.ex
+++ b/lib/remit_web/live_view_helpers.ex
@@ -96,6 +96,12 @@ defmodule RemitWeb.LiveViewHelpers do
     Map.merge(default, Map.get(session, "reviewed_commit_cutoff", %{}))
   end
 
+  @default_build_commit_repos ["deploy-cluster"]
+
+  def get_build_commit_repos(session) do
+    Map.get(session, "build_commit_repos", @default_build_commit_repos)
+  end
+
   @feature_defaults %{
     "compact_design" => false,
     "advanced_filters" => false,

--- a/lib/remit_web/live_view_helpers.ex
+++ b/lib/remit_web/live_view_helpers.ex
@@ -29,14 +29,25 @@ defmodule RemitWeb.LiveViewHelpers do
 
     extra_classes = Keyword.get(opts, :class, "")
     tooltip = Keyword.get(opts, :tooltip, username)
-    tooltip_pos = Keyword.get(opts, :tooltip_pos, "up")
+    shape = Keyword.get(opts, :shape, :default)
+
+    {span_extra, img_class} =
+      case shape do
+        :hexagon ->
+          hex_clip = "polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)"
+          {[style: "clip-path: #{hex_clip}; overflow: hidden; width: #{size}px; height: #{size}px;"], "bg-gray-mid"}
+        _ ->
+          {[], "rounded-sm bg-gray-mid"}
+      end
+
+    title_attr = if tooltip, do: [title: tooltip], else: []
 
     # Setting CSS dimensions because the `size` param is not always respected.
-    content_tag(:span, tooltip_attributes(tooltip, pos: tooltip_pos) ++ [class: "block #{extra_classes}"]) do
+    content_tag(:span, title_attr ++ [class: "block #{extra_classes}"] ++ span_extra) do
       img_tag(
         "https://github.com/#{username}.png?size=#{size}",
         alt: "",
-        class: "rounded-sm bg-gray-mid",
+        class: img_class,
         style: "height: #{size}px; width: #{size}px;"
       )
     end

--- a/lib/remit_web/router.ex
+++ b/lib/remit_web/router.ex
@@ -49,6 +49,7 @@ defmodule RemitWeb.Router do
     post "/filter_preference/:scope", UserController, :set_filter_preference
     post "/reviewed_commit_cutoff", UserController, :set_reviewed_commit_cutoff
     post "/features", UserController, :set_feature_flag
+    post "/build_commit_repos", UserController, :set_build_commit_repo
   end
 
   pipeline :webhook do

--- a/mix.exs
+++ b/mix.exs
@@ -88,6 +88,7 @@ defmodule Remit.MixProject do
       "fake.teams": ["run priv/repo/fake_teams.exs"],
       "wh.commits": ["run priv/repo/fake_webhook_commits.exs"],
       "wh.comments": ["run priv/repo/fake_webhook_comments.exs"],
+      "wh.build_commits": ["run priv/repo/fake_build_commits.exs"],
       "fake.notifications": ["run priv/repo/fake_notifications.exs"]
     ]
   end

--- a/priv/repo/fake_build_commits.exs
+++ b/priv/repo/fake_build_commits.exs
@@ -1,0 +1,85 @@
+# Sends fake build/deploy commits that reference existing commit SHAs.
+# These are the kind of commits created by a CD system when deploying a service
+# (e.g. updating a k8s cluster's revision file).
+# Usage: mix run priv/repo/fake_build_commits.exs [--repo stack] [--count 3]
+
+{opts, _, _} =
+  OptionParser.parse(System.argv(),
+    strict: [count: :integer, repo: :string]
+  )
+
+import Ecto.Query
+
+repo = Keyword.get(opts, :repo, "stack")
+count = Keyword.get(opts, :count, 3)
+
+port =
+  if System.get_env("DEVBOX") do
+    45361
+  else
+    System.get_env("PORT") |> String.to_integer()
+  end
+
+# Pick existing non-build commit SHAs to reference.
+shas =
+  Remit.Repo.all(
+    from c in Remit.Commit,
+      where: is_nil(c.deployed_sha),
+      where: not is_nil(c.sha),
+      order_by: [desc: c.id],
+      select: c.sha,
+      limit: ^count
+  )
+
+if shas == [] do
+  IO.puts("No existing commits found. Run fake_webhook_commits.exs first.")
+  System.halt(0)
+end
+
+IO.puts("Hi! Sending #{length(shas)} build commit(s) to the webhook…")
+IO.puts("")
+
+Enum.each(shas, fn sha ->
+  message = "#{sha} Deploy to production"
+
+  json =
+    Jason.encode!(
+      %{
+        ref: "refs/heads/master",
+        repository: %{
+          master_branch: "master",
+          name: repo,
+          owner: %{name: "acme"}
+        },
+        commits: [
+          %{
+            author: %{email: "deploy@example.com", username: "deploy-bot[bot]"},
+            committer: %{email: "deploy@example.com", username: "deploy-bot[bot]"},
+            id: Faker.sha(),
+            url: "https://example.com/",
+            message: message,
+            timestamp: DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+          }
+        ]
+      },
+      escape: :unicode_safe
+    )
+    |> String.to_charlist()
+
+  IO.puts("  Deploying #{String.slice(sha, 0, 8)}… via #{repo}")
+
+  :httpc.request(
+    :post,
+    {
+      ~c"http://localhost:#{port}/webhooks/github?auth_key=dev",
+      [{~c"x-github-event", ~c"push"}],
+      ~c"application/json",
+      json
+    },
+    [],
+    []
+  )
+end)
+
+IO.puts("")
+IO.puts("Done!")

--- a/priv/repo/fake_build_commits.exs
+++ b/priv/repo/fake_build_commits.exs
@@ -1,7 +1,7 @@
 # Sends fake build/deploy commits that reference existing commit SHAs.
 # These are the kind of commits created by a CD system when deploying a service
 # (e.g. updating a k8s cluster's revision file).
-# Usage: mix run priv/repo/fake_build_commits.exs [--repo stack] [--count 3]
+# Usage: mix run priv/repo/fake_build_commits.exs [--repo deploy-cluster] [--count 3]
 
 {opts, _, _} =
   OptionParser.parse(System.argv(),
@@ -10,8 +10,12 @@
 
 import Ecto.Query
 
-repo = Keyword.get(opts, :repo, "stack")
+repos = if opts[:repo], do: [opts[:repo]], else: ["deploy-cluster", "auctionet"]
 count = Keyword.get(opts, :count, 3)
+
+# When using defaults, reserve extra SHAs for the named variants (multi-line, 8-digit).
+extra_variants = if opts[:repo], do: 0, else: 2
+total_needed = count + extra_variants
 
 port =
   if System.get_env("DEVBOX") do
@@ -20,54 +24,30 @@ port =
     System.get_env("PORT") |> String.to_integer()
   end
 
-# Pick existing non-build commit SHAs to reference.
+already_deployed =
+  Remit.Repo.all(from c in Remit.Commit, where: not is_nil(c.deployed_sha), select: c.deployed_sha)
+
 shas =
   Remit.Repo.all(
     from c in Remit.Commit,
       where: is_nil(c.deployed_sha),
       where: not is_nil(c.sha),
+      where: is_nil(c.reviewed_at),
+      where: c.sha not in ^already_deployed,
       order_by: [desc: c.id],
       select: c.sha,
-      limit: ^count
+      limit: ^total_needed
   )
 
 if shas == [] do
-  IO.puts("No existing commits found. Run fake_webhook_commits.exs first.")
+  IO.puts("No unreviewed undeployed commits found. Run fake_webhook_commits.exs first.")
   System.halt(0)
 end
 
-IO.puts("Hi! Sending #{length(shas)} build commit(s) to the webhook…")
+IO.puts("Hi! Sending build commit(s) to the webhook…")
 IO.puts("")
 
-Enum.each(shas, fn sha ->
-  message = "#{sha} Deploy to production"
-
-  json =
-    Jason.encode!(
-      %{
-        ref: "refs/heads/master",
-        repository: %{
-          master_branch: "master",
-          name: repo,
-          owner: %{name: "acme"}
-        },
-        commits: [
-          %{
-            author: %{email: "deploy@example.com", username: "deploy-bot[bot]"},
-            committer: %{email: "deploy@example.com", username: "deploy-bot[bot]"},
-            id: Faker.sha(),
-            url: "https://example.com/",
-            message: message,
-            timestamp: DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
-          }
-        ]
-      },
-      escape: :unicode_safe
-    )
-    |> String.to_charlist()
-
-  IO.puts("  Deploying #{String.slice(sha, 0, 8)}… via #{repo}")
-
+post_webhook = fn json ->
   :httpc.request(
     :post,
     {
@@ -79,7 +59,51 @@ Enum.each(shas, fn sha ->
     [],
     []
   )
-end)
+end
+
+build_commit_json = fn repo, message ->
+  Jason.encode!(
+    %{
+      ref: "refs/heads/master",
+      repository: %{master_branch: "master", name: repo, owner: %{name: "acme"}},
+      commits: [
+        %{
+          author: %{email: "deploy@example.com", username: "deploy-bot[bot]"},
+          committer: %{email: "deploy@example.com", username: "deploy-bot[bot]"},
+          id: Faker.sha(),
+          url: "https://example.com/",
+          message: message,
+          timestamp: DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+        }
+      ]
+    },
+    escape: :unicode_safe
+  )
+  |> String.to_charlist()
+end
+
+# Regular build commits: one SHA per repo (no cartesian product to avoid cross-repo duplicates).
+loop_shas = Enum.take(shas, count)
+
+for {repo, sha} <- Enum.zip(Stream.cycle(repos), loop_shas) do
+  IO.puts("  Deploying #{String.slice(sha, 0, 8)}… via #{repo}")
+  post_webhook.(build_commit_json.(repo, "#{sha} Deploy to production"))
+end
+
+if !opts[:repo] do
+  # Multi-line build commit: 40-char SHA prefix + extra lines (must still be caught by build_commit?).
+  if length(shas) > count do
+    sha = Enum.at(shas, count)
+    message = "#{sha} Deploy to production\n\nUpdated:\n- deploy-cluster/app-a/deployment.yaml\n- deploy-cluster/app-b/deployment.yaml"
+    IO.puts("  Deploying #{String.slice(sha, 0, 8)}… via deploy-cluster (multi-line)")
+    post_webhook.(build_commit_json.("deploy-cluster", message))
+  end
+
+  # 8-digit SHA in title: must NOT be caught by build_commit? and must be reviewable.
+  short_sha = String.slice(Faker.sha(), 0, 8)
+  IO.puts("  Sending short-sha deploy commit #{short_sha}… via deploy-cluster")
+  post_webhook.(build_commit_json.("deploy-cluster", "#{short_sha} Deploy to production"))
+end
 
 IO.puts("")
 IO.puts("Done!")

--- a/priv/repo/fake_webhook_comments.exs
+++ b/priv/repo/fake_webhook_comments.exs
@@ -10,7 +10,7 @@ shas =
   if for_user != nil do
     commits =
       Remit.Commits.list_latest(100)
-      |> Enum.filter(fn c -> Enum.member?(c.usernames, for_user) end)
+      |> Enum.filter(fn c -> c.usernames == [for_user] end)
       |> Enum.map(& &1.sha)
 
     if Enum.empty?(commits) do
@@ -43,7 +43,7 @@ started_at = DateTime.utc_now() |> DateTime.truncate(:microsecond)
       %{
         action: "created",
         comment: %{
-          id: Faker.number(),
+          id: :erlang.unique_integer([:positive]),
           user: %{
             login: if(all_usernames, do: Enum.random(all_usernames), else: Faker.username())
           },
@@ -51,7 +51,7 @@ started_at = DateTime.utc_now() |> DateTime.truncate(:microsecond)
           position: nil,
           path: nil,
           created_at: "2016-01-25T08:41:25+01:00",
-          body: Faker.comment()
+          body: if(Enum.random(1..5) <= 1, do: Faker.paragraph_comment(), else: Faker.comment())
         },
         repository: %{
           name: Faker.repo(),

--- a/priv/repo/fake_webhook_commits.exs
+++ b/priv/repo/fake_webhook_commits.exs
@@ -75,6 +75,49 @@ else
     end
 
   Enum.each(batches, fn {repo, author, count} -> send_commits.(repo, author, count) end)
+
+  # Commits whose message starts with an 8-char short SHA (not 40-char, so never a build commit).
+  short_sha_cases = [
+    {"auctionet", Faker.username(), String.slice(Faker.sha(), 0, 8) <> " " <> Faker.message()},
+    {"deploy-cluster", Faker.username(), String.slice(Faker.sha(), 0, 8) <> " Update deploy config"},
+    {Faker.repo(), Faker.username(), String.slice(Faker.sha(), 0, 8) <> " " <> Faker.message()}
+  ]
+
+  Enum.each(short_sha_cases, fn {repo, author, message} ->
+    json =
+      Jason.encode!(
+        %{
+          ref: "refs/heads/master",
+          repository: %{master_branch: "master", name: repo, owner: %{name: "acme"}},
+          commits: [
+            %{
+              author: %{email: Faker.email(), username: author},
+              committer: %{email: Faker.email(), username: Faker.username()},
+              id: Faker.sha(),
+              url: "https://example.com/",
+              message: message,
+              timestamp: DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+            }
+          ]
+        },
+        escape: :unicode_safe
+      )
+      |> String.to_charlist()
+
+    IO.puts("  Sending short-sha commit by #{author} on #{repo}…")
+
+    :httpc.request(
+      :post,
+      {
+        ~c"http://localhost:#{port}/webhooks/github?auth_key=dev",
+        [{~c"x-github-event", ~c"push"}],
+        ~c"application/json",
+        json
+      },
+      [],
+      []
+    )
+  end)
 end
 
 IO.puts("")

--- a/priv/repo/migrations/20260516110236_add_deployed_sha_to_commits.exs
+++ b/priv/repo/migrations/20260516110236_add_deployed_sha_to_commits.exs
@@ -1,0 +1,11 @@
+defmodule Remit.Repo.Migrations.AddDeployedShaToCommits do
+  use Ecto.Migration
+
+  def change do
+    alter table(:commits) do
+      add :deployed_sha, :string
+    end
+
+    create index(:commits, [:deployed_sha])
+  end
+end


### PR DESCRIPTION
A small revamp and some additional filtering features:

- a more flat, modern design
- expandable filters
- a search field (it can filter by commit message and sha)
- filter by repo

New design is opt-in with a usage counter.

Screenshots:

<img width="775" height="716" alt="image" src="https://github.com/user-attachments/assets/097bb99c-3101-46ab-99ae-a9b118c22fc1" />

<hr>

<img width="781" height="330" alt="image" src="https://github.com/user-attachments/assets/13c8aeb7-7281-4170-9d0c-d903af92e00a" />

<hr>
<img width="518" height="719" alt="image" src="https://github.com/user-attachments/assets/78fb2e84-f338-4f6c-ae18-f36c0f77b58b" />
