### PR TITLE
Fix: Apply author filter to live-updated commits

### DIFF
--- a/lib/remit_web/live/commits/commits_live.ex
+++ b/lib/remit_web/live/commits/commits_live.ex
@@ -102,10 +102,12 @@ defmodule RemitWeb.CommitsLive do
 
     projects_of_team = projects_of_team(socket)
     members_of_team = members_of_team(socket)
+    author_filter = commits_of_author(socket)
 
     commit_for_display? = fn commit ->
       Ownership.claimed_by_team_or_unclaimed?(commit.repo, projects_of_team) &&
-        Ownership.authors_in_team?(commit.usernames, members_of_team)
+        Ownership.authors_in_team?(commit.usernames, members_of_team) &&
+        commit_matches_author_filter?(commit, author_filter)
     end
 
     case Enum.filter(new_commits, commit_for_display?) do
@@ -251,6 +253,9 @@ defmodule RemitWeb.CommitsLive do
   defp replace_commit(commits, commit) do
     commits |> Enum.map(&if(&1.id == commit.id, do: commit, else: &1))
   end
+
+  defp commit_matches_author_filter?(_commit, "all"), do: true
+  defp commit_matches_author_filter?(commit, author), do: Commit.authored_by?(commit, author)
 
   defp authored?(socket, commit), do: Commit.authored_by?(commit, username(socket))
 

--- a/test/remit_web/live/commits_live_test.exs
+++ b/test/remit_web/live/commits_live_test.exs
@@ -28,7 +28,7 @@ defmodule RemitWeb.CommitsLiveTest do
       %{conn: conn}
     end
 
-    test "shows commits you've made", %{conn: conn} do
+    test "shows commits you've made, including ones arriving via live update", %{conn: conn} do
       commit_not_by_me =
         Factory.insert!(:commit,
           usernames: ["michael"],
@@ -49,11 +49,19 @@ defmodule RemitWeb.CommitsLiveTest do
       assert view |> has_element?("p", commit_not_by_me.message)
       assert view |> has_element?("p", commit_by_me.message)
 
-      # filter by me
+      # Filter by me.
       assert commits_lv |> element("a", "Me") |> render_click()
 
       refute view |> has_element?("p", commit_not_by_me.message)
       assert view |> has_element?("p", commit_by_me.message)
+
+      # Filter also applies to commits arriving via live update.
+      new_commit_by_me = Factory.build(:commit, id: 1, usernames: ["dwight"], message: "new commit by dwight")
+      new_commit_by_other = Factory.build(:commit, id: 2, usernames: ["michael"], message: "new commit by michael")
+      send(commits_lv.pid, {:new_commits, [new_commit_by_me, new_commit_by_other]})
+
+      assert render(commits_lv) =~ new_commit_by_me.message
+      refute render(commits_lv) =~ new_commit_by_other.message
     end
   end
 


### PR DESCRIPTION
## Summary

- Fixes bug where the "Authored by me" filter only applied to commits already on the page, not to new commits arriving via live updates
- Adds `commit_matches_author_filter?/2` helper that checks if a commit matches the current author filter
- Applies this check in `handle_info({:new_commits, ...})` alongside the existing team/project filters
- Adds test to verify that live-updated commits respect the author filter

> **Note:** This is a Claude attempt without human sign-off. Please review carefully.

## Test plan

- [ ] Set the "Authored by me" filter
- [ ] Have another user push a commit
- [ ] Verify the commit does NOT appear in your filtered view
- [ ] Switch filter back to "All" and verify the commit appears

Slack thread: https://auctionet.slack.com/archives/C0347E98T52/p1778318149428599?thread_ts=1778243580.347039&cid=C0347E98T52

https://claude.ai/code/session_01774u68TfUYWMbWpBj4MFVU